### PR TITLE
ci: add least-privilege permissions to build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
     name: Build, compile & test
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds explicit `permissions: { contents: read }` to the build job, resolving the CodeQL `actions/missing-workflow-permissions` code-scanning alert in build.yml.

The 49 dependency CVEs are build-toolchain transitive deps (AGP/Kotlin Gradle plugin: Netty, protobuf, BouncyCastle, commons-compress) — not M0.5 runtime code — and are handled by Dependabot PRs.