### PR TITLE
M1 hardening: workspace path confinement, WAL self-heal, module promotion

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/agent/code/M1RealIoTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/agent/code/M1RealIoTest.kt
@@ -22,7 +22,7 @@ class M1RealIoTest {
     @Test
     fun realFileSystemReadWriteExists() {
         val dir = createTempDirectory("m1-fs").toFile()
-        val fs = RealFileSystem()
+        val fs = RealFileSystem(VirtualPath.of(dir.absolutePath))
         val path = VirtualPath.of("${dir.absolutePath}/sub/note.txt")
 
         assertFalse(fs.exists(path))
@@ -79,7 +79,7 @@ class M1RealIoTest {
         runner.run(listOf("git", "-C", dir.absolutePath, "config", "user.email", "m1@agent.code")).getOrThrow()
         runner.run(listOf("git", "-C", dir.absolutePath, "config", "user.name", "M1")).getOrThrow()
 
-        val fs = RealFileSystem()
+        val fs = RealFileSystem(VirtualPath.of(dir.absolutePath))
         val target = VirtualPath.of("${dir.absolutePath}/hello.txt")
         fs.write(target, "hello world").getOrThrow()
         runner.run(listOf("git", "-C", dir.absolutePath, "add", "hello.txt")).getOrThrow()
@@ -128,5 +128,50 @@ class M1RealIoTest {
         val script = "i=0; while [ \$i -lt 100000 ]; do printf E >&2; i=\$((i+1)); done"
         val res = runner.run(listOf("sh", "-c", script))
         assertTrue(res.isSuccess, "stderr-heavy process should finish: ${res.exceptionOrNull()?.message}")
+    }
+
+    @Test
+    fun realFileSystemBlocksTraversalOutsideRoot() {
+        val dir = createTempDirectory("m1-fs-esc").toFile()
+        val fs = RealFileSystem(VirtualPath.of(dir.absolutePath))
+        val escape = VirtualPath.of("${dir.absolutePath}/../agentcode-escape.txt")
+        assertTrue(fs.read(escape).isFailure, "read outside root must fail")
+        assertTrue(fs.write(escape, "x").isFailure, "write outside root must fail")
+        assertFalse(fs.exists(escape), "exists outside root must be false")
+    }
+
+    @Test
+    fun fileBackedWalSelfHealsCorruptLine() {
+        val file = createTempDirectory("m1-wal-heal").resolve("wal.log").toFile()
+        file.writeText("{\"valid\":1}\nthis is corrupt\n{\"valid\":2}\n")
+        val store = FileBackedWalStore(file)
+        assertEquals(1, store.selfHeal())
+        assertEquals(2, store.replay().size)
+    }
+
+    @Test
+    fun promoteToMainSquashesIntoMain() = runBlocking {
+        val dir = createTempDirectory("m1-promote").toFile()
+        val runner = GitProcessRunner()
+        val root = VirtualPath.of(dir.absolutePath)
+        runner.run(listOf("git", "init", "-q", dir.absolutePath)).getOrThrow()
+        runner.run(listOf("git", "-C", dir.absolutePath, "config", "user.email", "m1@agent.code")).getOrThrow()
+        runner.run(listOf("git", "-C", dir.absolutePath, "config", "user.name", "M1")).getOrThrow()
+        dir.resolve("base.txt").writeText("base")
+        runner.run(listOf("git", "-C", dir.absolutePath, "add", "base.txt")).getOrThrow()
+        runner.run(listOf("git", "-C", dir.absolutePath, "commit", "-q", "-m", "seed")).getOrThrow()
+        runner.run(listOf("git", "-C", dir.absolutePath, "branch", "-M", "main")).getOrThrow()
+
+        val wm = WorktreeManager(root, runner)
+        val wt = wm.createSparseWorktree("T1", emptyList()).getOrThrow()
+        JFile(wt.rawPath, "feature.txt").writeText("feature work")
+        runner.run(listOf("git", "-C", wt.rawPath, "add", "feature.txt")).getOrThrow()
+        runner.run(listOf("git", "-C", wt.rawPath, "commit", "-q", "-m", "add feature")).getOrThrow()
+
+        wm.promoteToMain("T1").getOrThrow()
+
+        assertTrue(JFile(dir, "feature.txt").exists(), "promoted feature should land on main")
+        val branches = runner.run(listOf("git", "-C", root.rawPath, "branch")).getOrThrow()
+        assertFalse(branches.contains("agent/task-T1"), "task branch should be removed after promotion")
     }
 }

--- a/shared/src/androidMain/kotlin/com/agent/code/core/journal/FileBackedWalStore.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/core/journal/FileBackedWalStore.kt
@@ -3,12 +3,37 @@ package com.agent.code.core.journal
 import java.io.File
 import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
+import kotlinx.serialization.json.JsonElement
 
 class FileBackedWalStore(private val file: File) : WalStore {
     private val lock = Any()
 
     init {
         file.parentFile?.mkdirs()
+    }
+
+    // ponytail: at startup, drop torn/unparseable lines so a half-written
+    // record can't poison every future replay. Returns how many lines pruned.
+    override fun selfHeal(): Int = synchronized(lock) {
+        if (!file.exists()) return 0
+        val lines = file.readLines()
+        val (good, bad) = lines.partition { it.isNotBlank() && safeJson(it) }
+        if (bad.isEmpty()) return 0
+        FileOutputStream(file).use { os ->
+            good.forEach {
+                os.write((it + "\n").toByteArray(StandardCharsets.UTF_8))
+                os.flush()
+            }
+            os.fd.sync()
+        }
+        bad.size
+    }
+
+    private fun safeJson(line: String): Boolean = try {
+        eventJson.decodeFromString<JsonElement>(line)
+        true
+    } catch (_: Exception) {
+        false
     }
 
     override fun append(serialized: String) = synchronized(lock) {

--- a/shared/src/androidMain/kotlin/com/agent/code/core/journal/FileBackedWalStore.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/core/journal/FileBackedWalStore.kt
@@ -13,18 +13,37 @@ class FileBackedWalStore(private val file: File) : WalStore {
     }
 
     // ponytail: at startup, drop torn/unparseable lines so a half-written
-    // record can't poison every future replay. Returns how many lines pruned.
+    // record can't poison every future replay. Writes to a sibling temp file,
+    // fsyncs it, then atomically replaces the WAL — a crash mid-rewrite can't
+    // destroy valid recovery records. Returns how many lines pruned.
     override fun selfHeal(): Int = synchronized(lock) {
         if (!file.exists()) return 0
         val lines = file.readLines()
         val (good, bad) = lines.partition { it.isNotBlank() && safeJson(it) }
         if (bad.isEmpty()) return 0
-        FileOutputStream(file).use { os ->
-            good.forEach {
-                os.write((it + "\n").toByteArray(StandardCharsets.UTF_8))
-                os.flush()
+        val tmp = File(file.parentFile ?: File("."), "${file.name}.heal-${System.nanoTime()}")
+        try {
+            FileOutputStream(tmp).use { os ->
+                good.forEach {
+                    os.write((it + "\n").toByteArray(StandardCharsets.UTF_8))
+                    os.flush()
+                }
+                os.fd.sync()
             }
-            os.fd.sync()
+            if (!tmp.renameTo(file)) {
+                // ponytail: cross-device fallback (rename can't span filesystems)
+                FileOutputStream(file).use { os ->
+                    good.forEach {
+                        os.write((it + "\n").toByteArray(StandardCharsets.UTF_8))
+                        os.flush()
+                    }
+                    os.fd.sync()
+                }
+                tmp.delete()
+            }
+        } catch (e: Exception) {
+            tmp.delete()
+            throw e
         }
         bad.size
     }

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/M1RealIoDemo.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/M1RealIoDemo.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.launch
  */
 @Composable
 fun M1RealIoDemo(baseDir: String) {
-    val fs = remember { RealFileSystem() }
+    val fs = remember { RealFileSystem(VirtualPath.of(baseDir)) }
     val scope = rememberCoroutineScope()
     var result by remember { mutableStateOf<String?>(null) }
     Column(
@@ -62,14 +62,21 @@ fun M1RealIoDemo(baseDir: String) {
                 AgentEvent.TaskSucceeded(2, "ui-probe", System.currentTimeMillis(), "durable WAL recovered"),
             )
             events.forEach { store.append(eventJson.encodeToString(it)) }
+            val pruned = store.selfHeal()
             val recovered = FileBackedWalStore(walFile).replay()
             val walLine = if (recovered.size == events.size) {
-                "Durable WAL OK: ${recovered.size} events recovered after restart"
+                "Durable WAL OK: ${recovered.size} events recovered after restart" + if (pruned > 0) " ($pruned corrupt pruned)" else ""
             } else {
                 "WAL MISMATCH: expected ${events.size}, got ${recovered.size}"
             }
 
-            result = "$fsLine\n\n$walLine"
+            val escape = VirtualPath.of("$baseDir/../agentcode-escape.txt")
+            val traversalLine = fs.read(escape).fold(
+                onSuccess = { "TRAVERSAL NOT BLOCKED (read: $it)" },
+                onFailure = { "Traversal blocked: ${it.message}" },
+            )
+
+            result = "$fsLine\n\n$walLine\n\n$traversalLine"
             }
         }) {
             Text("Run M1 Real IO Probe")

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/M1RealIoDemo.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/M1RealIoDemo.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.launch
  */
 @Composable
 fun M1RealIoDemo(baseDir: String) {
-    val fs = remember { RealFileSystem(VirtualPath.of(baseDir)) }
+    val fs = remember(baseDir) { RealFileSystem(VirtualPath.of(baseDir)) }
     val scope = rememberCoroutineScope()
     var result by remember { mutableStateOf<String?>(null) }
     Column(

--- a/shared/src/androidMain/kotlin/com/agent/code/workspace/RealFileSystem.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/workspace/RealFileSystem.kt
@@ -5,51 +5,74 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.nio.charset.StandardCharsets
 
-class RealFileSystem : FileSystemProvider {
-    override fun read(path: VirtualPath): Result<String> = try {
-        val file = File(path.rawPath)
-        if (!file.exists()) {
-            Result.failure(FileError.NotFound(path, "file not found"))
-        } else {
-            Result.success(file.readText(StandardCharsets.UTF_8))
+class RealFileSystem(private val root: VirtualPath) : FileSystemProvider {
+    private val canonicalRoot = File(root.rawPath).canonicalPath
+
+    // ponytail: confine every path to the workspace root; rejects `../../`
+    // escapes and absolute paths outside root. Real backend touches real disk,
+    // so LLM-supplied paths must never reach files outside the sandbox.
+    private fun confinedFile(path: VirtualPath): Result<File> {
+        val raw = File(path.rawPath)
+        val canonical = if (raw.isAbsolute) raw.canonicalPath else File(canonicalRoot, path.rawPath).canonicalPath
+        val confined = canonical == canonicalRoot || canonical.startsWith("$canonicalRoot${File.separator}")
+        if (!confined) {
+            return Result.failure(FileError.PermissionDenied(path, "path escapes workspace root: $canonical"))
         }
-    } catch (e: SecurityException) {
-        Result.failure(FileError.PermissionDenied(path, e.message ?: "read denied"))
-    } catch (e: FileNotFoundException) {
-        Result.failure(FileError.NotFound(path, "file not found"))
-    } catch (e: Exception) {
-        Result.failure(FileError.IOError(path, e.message ?: "read failed", e))
+        return Result.success(File(canonical))
     }
 
-    override fun write(path: VirtualPath, content: String): Result<Unit> = try {
-        val target = File(path.rawPath)
-        val parent = target.parentFile ?: File(".")
-        parent.mkdirs()
-        val tmp = File(parent, "${target.name}.tmp-${System.nanoTime()}")
-        try {
-            tmp.outputStream().use { os ->
-                os.write(content.toByteArray(StandardCharsets.UTF_8))
-                os.flush()
-                // ponytail: fsync before rename so a crash mid-write can't leave a
-                // torn target; upgrade to dir fsync if durability must survive power
-                // loss, not just process crash.
-                os.fd.sync()
+    override fun read(path: VirtualPath): Result<String> = confinedFile(path).fold(
+        onSuccess = { file ->
+            try {
+                if (!file.exists()) {
+                    Result.failure(FileError.NotFound(path, "file not found"))
+                } else {
+                    Result.success(file.readText(StandardCharsets.UTF_8))
+                }
+            } catch (e: SecurityException) {
+                Result.failure(FileError.PermissionDenied(path, e.message ?: "read denied"))
+            } catch (e: FileNotFoundException) {
+                Result.failure(FileError.NotFound(path, "file not found"))
+            } catch (e: Exception) {
+                Result.failure(FileError.IOError(path, e.message ?: "read failed", e))
             }
-            if (!tmp.renameTo(target)) {
-                target.writeText(content, StandardCharsets.UTF_8)
-                tmp.delete()
+        },
+        onFailure = { Result.failure(it) }
+    )
+
+    override fun write(path: VirtualPath, content: String): Result<Unit> = confinedFile(path).fold(
+        onSuccess = { target ->
+            try {
+                val parent = target.parentFile ?: File(".")
+                parent.mkdirs()
+                val tmp = File(parent, "${target.name}.tmp-${System.nanoTime()}")
+                try {
+                    tmp.outputStream().use { os ->
+                        os.write(content.toByteArray(StandardCharsets.UTF_8))
+                        os.flush()
+                        // ponytail: fsync before rename so a crash mid-write can't leave a
+                        // torn target; upgrade to dir fsync if durability must survive power
+                        // loss, not just process crash.
+                        os.fd.sync()
+                    }
+                    if (!tmp.renameTo(target)) {
+                        target.writeText(content, StandardCharsets.UTF_8)
+                        tmp.delete()
+                    }
+                    Result.success(Unit)
+                } catch (e: Exception) {
+                    tmp.delete()
+                    throw e
+                }
+            } catch (e: SecurityException) {
+                Result.failure(FileError.PermissionDenied(path, e.message ?: "write denied"))
+            } catch (e: Exception) {
+                Result.failure(FileError.IOError(path, e.message ?: "write failed", e))
             }
-            Result.success(Unit)
-        } catch (e: Exception) {
-            tmp.delete()
-            throw e
-        }
-    } catch (e: SecurityException) {
-        Result.failure(FileError.PermissionDenied(path, e.message ?: "write denied"))
-    } catch (e: Exception) {
-        Result.failure(FileError.IOError(path, e.message ?: "write failed", e))
-    }
+        },
+        onFailure = { Result.failure(it) }
+    )
 
     override fun exists(path: VirtualPath): Boolean =
-        File(path.rawPath).exists()
+        confinedFile(path).fold({ it.exists() }, { false })
 }

--- a/shared/src/commonMain/kotlin/com/agent/code/core/journal/WalStore.kt
+++ b/shared/src/commonMain/kotlin/com/agent/code/core/journal/WalStore.kt
@@ -4,4 +4,7 @@ interface WalStore {
     fun append(serialized: String)
     fun replay(): List<String>
     fun clear()
+    // ponytail: prune corrupt lines from the durable log; default no-op for
+    // in-memory stores. Real backends override to rewrite the file.
+    fun selfHeal(): Int = 0
 }

--- a/shared/src/commonMain/kotlin/com/agent/code/workspace/WorktreeManager.kt
+++ b/shared/src/commonMain/kotlin/com/agent/code/workspace/WorktreeManager.kt
@@ -43,4 +43,8 @@ class WorktreeManager(
             .onFailure { return Result.failure(it) }
         return Result.success(Unit)
     }
+
+    // ponytail: module promotion == squash-merge a finished task worktree into
+    // main. (Opening the resulting commit as a PR is out of app scope.)
+    suspend fun promoteToMain(taskId: String): Result<Unit> = finalizeAndSquashBranch(taskId, "main")
 }


### PR DESCRIPTION
## Summary
Closes the remaining M1-deferred items in efficient order:

1. **Path-traversal hardening (closes #23)** — `RealFileSystem` now takes a workspace `root` and rejects `../../` escapes and absolute paths outside it. `ReadFileTool`/`ApplyPatchTool` inherit the protection because they route through the provider. Device UI probe (`M1RealIoDemo`) now exercises confinement.
2. **StartupSelfHealer** — `WalStore.selfHeal()` prunes torn/unparseable WAL lines (real backend rewrites; in-memory is a no-op), so corruption can't poison every replay.
3. **Module promotion** — `WorktreeManager.promoteToMain()` is the documented squash-merge promotion path for a finished task worktree.

Deferred (filed as scoped issues, not buildable headless):
- #24 — on-device git via libgit2 (NDK) instead of git CLI
- #25 — privileged device IO via Shizuku

## Test plan
- `:shared:testAndroidHostTest` green, including new `realFileSystemBlocksTraversalOutsideRoot`, `fileBackedWalSelfHealsCorruptLine`, `promoteToMainSquashesIntoMain`.
- `:shared:compileAndroidMain` and `:androidApp:compileDebugKotlin` green.
- Only warning is the pre-existing `LocalClipboardManager` deprecation in `App.kt` (unrelated).

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to promote a task worktree into the main branch, including branch cleanup.
  - Added automatic recovery for corrupted write-ahead log entries while preserving valid records.
  - Added workspace path protection to block file access outside the configured root.

- **Improvements**
  - Demo output now reports repaired log entries and blocked traversal attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->