### PR TITLE
feat: M2 deferred items + device stats + crash fixes

### DIFF
--- a/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.agent.code.core.power.AndroidPowerGovernor
 import com.agent.code.ui.ProbeDashboard
 
 class MainActivity : ComponentActivity() {
@@ -13,8 +14,12 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
+        val governor = AndroidPowerGovernor(applicationContext)
+
         setContent {
-            App(probeDashboard = { ProbeDashboard(baseDir = filesDir.absolutePath) })
+            App(probeDashboard = {
+                ProbeDashboard(baseDir = filesDir.absolutePath, governor = governor)
+            })
         }
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/agent/code/M2ConcurrencyTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/agent/code/M2ConcurrencyTest.kt
@@ -3,6 +3,7 @@ package com.agent.code
 import com.agent.code.core.concurrency.EnergyAwareDispatchers
 import com.agent.code.core.fsm.AgentOrchestrator
 import com.agent.code.core.fsm.AgentState
+import com.agent.code.core.fsm.OperatingProfile
 import com.agent.code.core.fsm.StepResult
 import com.agent.code.core.fsm.ToolCall
 import com.agent.code.core.journal.AgentEventJournal
@@ -10,6 +11,7 @@ import com.agent.code.core.journal.InMemoryWalStore
 import com.agent.code.core.journal.TelemetryEngine
 import com.agent.code.core.lock.*
 import com.agent.code.core.path.VirtualPath
+import com.agent.code.core.power.StubPowerGovernor
 import com.agent.code.core.policy.AutonomyPolicy
 import com.agent.code.mcp.McpHost
 import com.agent.code.workspace.InMemoryFileSystem
@@ -109,15 +111,68 @@ class M2ConcurrencyTest {
     } }
 
     @Test
-    fun funnelStubReturnsPassed() { runBlocking {
+    fun funnelNoTestRunnerPasses() { runBlocking {
         val funnel = SemanticConflictFunnel(WorkspaceLockManager())
-        assertIs<SemanticVerificationResult.Passed>(funnel.verifyBranchIntegration("main", listOf(VirtualPath.of("/a.kt"))))
+        assertIs<SemanticVerificationResult.Passed>(
+            funnel.verifyBranchIntegration("main", listOf(VirtualPath.of("/a.kt")))
+        )
+    } }
+
+    @Test
+    fun funnelTier3RunsTestsOnChangedFiles() { runBlocking {
+        var executedCommand: List<String>? = null
+        val runner = object : com.agent.code.workspace.ProcessRunner {
+            override suspend fun run(command: List<String>): Result<String> {
+                executedCommand = command
+                return Result.success("BUILD SUCCESSFUL")
+            }
+        }
+        val funnel = SemanticConflictFunnel(WorkspaceLockManager(), runner)
+
+        val result = funnel.verifyBranchIntegration("main", listOf(VirtualPath.of("/src/MyTest.kt")))
+        assertIs<SemanticVerificationResult.Passed>(result)
+        assertTrue(executedCommand != null, "Test runner should have been invoked")
+        assertTrue(executedCommand!!.contains("test"), "Should run gradle test")
+    } }
+
+    @Test
+    fun funnelTier3ReportsFailure() { runBlocking {
+        val runner = object : com.agent.code.workspace.ProcessRunner {
+            override suspend fun run(command: List<String>): Result<String> =
+                Result.failure(RuntimeException("2 tests failed"))
+        }
+        val funnel = SemanticConflictFunnel(WorkspaceLockManager(), runner)
+
+        val result = funnel.verifyBranchIntegration("main", listOf(VirtualPath.of("/src/BrokenTest.kt")))
+        assertIs<SemanticVerificationResult.Failed>(result)
+        assertTrue(result.reason.contains("tests failed"))
+    } }
+
+    @Test
+    fun funnelTier3SkipsEmptyChangeset() { runBlocking {
+        var invoked = false
+        val runner = object : com.agent.code.workspace.ProcessRunner {
+            override suspend fun run(command: List<String>): Result<String> {
+                invoked = true
+                return Result.success("ok")
+            }
+        }
+        val funnel = SemanticConflictFunnel(WorkspaceLockManager(), runner)
+        val result = funnel.verifyBranchIntegration("main", emptyList())
+        assertIs<SemanticVerificationResult.Passed>(result)
+        assertTrue(!invoked, "Should not invoke runner for empty changeset")
     } }
 
     @Test
     fun funnelPreWriteCheckDelegatesToLockManager() {
         val funnel = SemanticConflictFunnel(WorkspaceLockManager())
         assertIs<ConflictRisk.None>(funnel.checkPreWriteCollision("t1", setOf("sym1")))
+    }
+
+    @Test
+    fun governorDefaultsToBalanced() {
+        val gov = StubPowerGovernor()
+        assertEquals(OperatingProfile.BALANCED_BATTERY, gov.currentProfile.value)
     }
 
     @Test

--- a/shared/src/androidMain/kotlin/com/agent/code/core/power/AndroidPowerGovernor.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/core/power/AndroidPowerGovernor.kt
@@ -8,6 +8,7 @@ import android.os.BatteryManager
 import android.os.Build
 import android.os.PowerManager
 import com.agent.code.core.fsm.OperatingProfile
+import java.io.File
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -16,7 +17,8 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * Monitors:
  * - Battery level via ACTION_BATTERY_CHANGED BroadcastReceiver
- * - Thermal status via PowerManager.getCurrentThermalStatus() (polled, API 29+)
+ * - Thermal status via PowerManager.getCurrentThermalStatus() (API 29+)
+ * - Actual temperature via /sys/class/thermal/thermal_zoneN/temp (millidegrees C)
  *
  * Emits [OperatingProfile] changes via [currentProfile] StateFlow.
  */
@@ -28,6 +30,7 @@ class AndroidPowerGovernor(context: Context) : PowerGovernor {
     private var thermalStatus = PowerManager.THERMAL_STATUS_NONE
     private var isPluggedIn = false
     private var batteryLevelPercent = 100
+    private var maxTemperatureCelsius = 0f
 
     private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
 
@@ -41,6 +44,7 @@ class AndroidPowerGovernor(context: Context) : PowerGovernor {
                 val scale = it.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
                 batteryLevelPercent = if (scale > 0) (level * 100) / scale else 100
                 pollThermalStatus()
+                readTemperatures()
                 evaluateProfile()
             }
         }
@@ -60,6 +64,7 @@ class AndroidPowerGovernor(context: Context) : PowerGovernor {
             val scale = it.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
             batteryLevelPercent = if (scale > 0) (level * 100) / scale else 100
             pollThermalStatus()
+            readTemperatures()
             evaluateProfile()
         }
     }
@@ -67,6 +72,30 @@ class AndroidPowerGovernor(context: Context) : PowerGovernor {
     private fun pollThermalStatus() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             thermalStatus = powerManager.getCurrentThermalStatus()
+        }
+    }
+
+    /**
+     * Read actual CPU/battery temperatures from sysfs thermal zones.
+     * Values are in millidegrees Celsius (e.g. 35000 = 35°C).
+     * Reports the maximum across all zones.
+     */
+    private fun readTemperatures() {
+        try {
+            val thermalDir = File("/sys/class/thermal")
+            if (!thermalDir.exists()) return
+            var max = 0f
+            thermalDir.listFiles()?.filter { it.name.startsWith("thermal_zone") }?.forEach { zone ->
+                val tempFile = File(zone, "temp")
+                if (tempFile.exists()) {
+                    val raw = tempFile.readText().trim().toFloatOrNull() ?: return@forEach
+                    val celsius = if (raw > 1000) raw / 1000f else raw
+                    if (celsius > max) max = celsius
+                }
+            }
+            maxTemperatureCelsius = max
+        } catch (_: Exception) {
+            // sysfs may not be readable on all devices
         }
     }
 
@@ -86,6 +115,7 @@ class AndroidPowerGovernor(context: Context) : PowerGovernor {
         profile = currentProfile.value,
         batteryPercent = batteryLevelPercent,
         thermalStatus = thermalStatus,
+        temperatureCelsius = maxTemperatureCelsius,
         pluggedIn = isPluggedIn
     )
 }
@@ -94,6 +124,7 @@ data class GovernorSnapshot(
     val profile: OperatingProfile,
     val batteryPercent: Int,
     val thermalStatus: Int,
+    val temperatureCelsius: Float,
     val pluggedIn: Boolean
 ) {
     val thermalLabel: String get() = when (thermalStatus) {

--- a/shared/src/androidMain/kotlin/com/agent/code/core/power/AndroidPowerGovernor.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/core/power/AndroidPowerGovernor.kt
@@ -1,0 +1,109 @@
+package com.agent.code.core.power
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Build
+import android.os.PowerManager
+import com.agent.code.core.fsm.OperatingProfile
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Android AdaptivePowerGovernor (§2.3 Development_Doc.md).
+ *
+ * Monitors:
+ * - Battery level via ACTION_BATTERY_CHANGED BroadcastReceiver
+ * - Thermal status via PowerManager.getCurrentThermalStatus() (polled, API 29+)
+ *
+ * Emits [OperatingProfile] changes via [currentProfile] StateFlow.
+ */
+class AndroidPowerGovernor(context: Context) : PowerGovernor {
+
+    private val _currentProfile = MutableStateFlow(OperatingProfile.BALANCED_BATTERY)
+    override val currentProfile: StateFlow<OperatingProfile> = _currentProfile
+
+    private var thermalStatus = PowerManager.THERMAL_STATUS_NONE
+    private var isPluggedIn = false
+    private var batteryLevelPercent = 100
+
+    private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+
+    private val batteryReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context?, intent: Intent?) {
+            intent?.let {
+                val status = it.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+                isPluggedIn = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                    status == BatteryManager.BATTERY_STATUS_FULL
+                val level = it.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+                val scale = it.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+                batteryLevelPercent = if (scale > 0) (level * 100) / scale else 100
+                pollThermalStatus()
+                evaluateProfile()
+            }
+        }
+    }
+
+    init {
+        val filter = IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+        context.registerReceiver(batteryReceiver, filter)
+
+        // Read initial battery state from sticky broadcast
+        val initialBattery = context.registerReceiver(null, filter)
+        initialBattery?.let {
+            val status = it.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+            isPluggedIn = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL
+            val level = it.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+            val scale = it.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+            batteryLevelPercent = if (scale > 0) (level * 100) / scale else 100
+            pollThermalStatus()
+            evaluateProfile()
+        }
+    }
+
+    private fun pollThermalStatus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            thermalStatus = powerManager.getCurrentThermalStatus()
+        }
+    }
+
+    private fun evaluateProfile() {
+        _currentProfile.value = when {
+            thermalStatus >= PowerManager.THERMAL_STATUS_SEVERE || batteryLevelPercent < 20 ->
+                OperatingProfile.ECO_PRESERVATION
+            isPluggedIn && thermalStatus <= PowerManager.THERMAL_STATUS_MODERATE ->
+                OperatingProfile.TURBO_PLUGGED
+            else ->
+                OperatingProfile.BALANCED_BATTERY
+        }
+    }
+
+    /** Expose for probe display. */
+    fun snapshot(): GovernorSnapshot = GovernorSnapshot(
+        profile = currentProfile.value,
+        batteryPercent = batteryLevelPercent,
+        thermalStatus = thermalStatus,
+        pluggedIn = isPluggedIn
+    )
+}
+
+data class GovernorSnapshot(
+    val profile: OperatingProfile,
+    val batteryPercent: Int,
+    val thermalStatus: Int,
+    val pluggedIn: Boolean
+) {
+    val thermalLabel: String get() = when (thermalStatus) {
+        PowerManager.THERMAL_STATUS_NONE -> "NONE"
+        PowerManager.THERMAL_STATUS_LIGHT -> "LIGHT"
+        PowerManager.THERMAL_STATUS_MODERATE -> "MODERATE"
+        PowerManager.THERMAL_STATUS_SEVERE -> "SEVERE"
+        PowerManager.THERMAL_STATUS_CRITICAL -> "CRITICAL"
+        PowerManager.THERMAL_STATUS_EMERGENCY -> "EMERGENCY"
+        PowerManager.THERMAL_STATUS_SHUTDOWN -> "SHUTDOWN"
+        else -> "UNKNOWN($thermalStatus)"
+    }
+}

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/DeviceStatsCollector.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/DeviceStatsCollector.kt
@@ -4,7 +4,6 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.opengl.GLES20
 import android.os.BatteryManager
 import android.os.Build
 import android.os.Environment
@@ -98,18 +97,16 @@ class DeviceStatsCollector(private val context: Context) {
     }
 
     private fun collectGpu(): DeviceStats.Gpu = try {
-        val vendor = GLES20.glGetString(GLES20.GL_VENDOR) ?: "unknown"
-        val renderer = GLES20.glGetString(GLES20.GL_RENDERER) ?: "unknown"
-        val version = GLES20.glGetString(GLES20.GL_VERSION) ?: "unknown"
-        val extensions = try { GLES20.glGetString(GLES20.GL_EXTENSIONS)?.split(" ")?.size ?: 0 } catch (_: Exception) { 0 }
+        val configInfo = am.deviceConfigurationInfo
+        val glueVersion = configInfo?.glEsVersion ?: "n/a"
         DeviceStats.Gpu(
-            vendor = vendor,
-            renderer = renderer,
-            glVersion = version,
-            extensionCount = extensions,
+            vendor = Build.HARDWARE,
+            renderer = configInfo?.reqGlEsVersion?.let { "ES $glueVersion" } ?: "n/a",
+            glVersion = glueVersion,
+            extensionCount = 0,
         )
     } catch (_: Exception) {
-        DeviceStats.Gpu("n/a", "n/a (no GL context)", "n/a", 0)
+        DeviceStats.Gpu("n/a", "n/a", "n/a", 0)
     }
 
     private fun collectDisplay(): DeviceStats.Display = try {

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/DeviceStatsCollector.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/DeviceStatsCollector.kt
@@ -97,25 +97,27 @@ class DeviceStatsCollector(private val context: Context) {
         )
     }
 
-    private fun collectGpu(): DeviceStats.Gpu {
+    private fun collectGpu(): DeviceStats.Gpu = try {
         val vendor = GLES20.glGetString(GLES20.GL_VENDOR) ?: "unknown"
         val renderer = GLES20.glGetString(GLES20.GL_RENDERER) ?: "unknown"
         val version = GLES20.glGetString(GLES20.GL_VERSION) ?: "unknown"
         val extensions = try { GLES20.glGetString(GLES20.GL_EXTENSIONS)?.split(" ")?.size ?: 0 } catch (_: Exception) { 0 }
-        return DeviceStats.Gpu(
+        DeviceStats.Gpu(
             vendor = vendor,
             renderer = renderer,
             glVersion = version,
             extensionCount = extensions,
         )
+    } catch (_: Exception) {
+        DeviceStats.Gpu("n/a", "n/a (no GL context)", "n/a", 0)
     }
 
-    private fun collectDisplay(): DeviceStats.Display {
+    private fun collectDisplay(): DeviceStats.Display = try {
         val dm = wm.defaultDisplay
         val metrics = android.util.DisplayMetrics()
         @Suppress("DEPRECATION")
         dm.getRealMetrics(metrics)
-        return DeviceStats.Display(
+        DeviceStats.Display(
             widthPx = metrics.widthPixels,
             heightPx = metrics.heightPixels,
             densityDpi = metrics.densityDpi,
@@ -128,6 +130,8 @@ class DeviceStatsCollector(private val context: Context) {
                 String.format("%.1f", diag).toDouble()
             },
         )
+    } catch (_: Exception) {
+        DeviceStats.Display(0, 0, 0, 0f, 0f, 0.0)
     }
 
     private fun collectBattery(): DeviceStats.Battery {

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/DeviceStatsCollector.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/DeviceStatsCollector.kt
@@ -1,0 +1,308 @@
+package com.agent.code.ui
+
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.opengl.GLES20
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Environment
+import android.os.StatFs
+import android.view.WindowManager
+import java.io.File
+
+/**
+ * Collects device hardware and performance stats for calibration.
+ * All reads are synchronous — call from IO dispatcher.
+ */
+class DeviceStatsCollector(private val context: Context) {
+    private val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    private val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    private val bm = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
+
+    fun collect(): DeviceStats = DeviceStats(
+        device = collectDevice(),
+        cpu = collectCpu(),
+        ram = collectRam(),
+        heap = collectHeap(),
+        storage = collectStorage(),
+        gpu = collectGpu(),
+        display = collectDisplay(),
+        battery = collectBattery(),
+        thermalZones = collectThermalZones(),
+    )
+
+    private fun collectDevice() = DeviceStats.Device(
+        manufacturer = Build.MANUFACTURER,
+        model = Build.MODEL,
+        hardware = Build.HARDWARE,
+        board = Build.BOARD,
+        abi = Build.SUPPORTED_ABIS.firstOrNull() ?: "unknown",
+        sdk = Build.VERSION.SDK_INT,
+        release = Build.VERSION.RELEASE,
+        securityPatch = Build.VERSION.SECURITY_PATCH,
+    )
+
+    private fun collectCpu(): DeviceStats.Cpu {
+        val coreCount = Runtime.getRuntime().availableProcessors()
+        val model = parseCpuInfo("/proc/cpuinfo", "Hardware")
+            ?: parseCpuInfo("/proc/cpuinfo", "model name")
+            ?: parseCpuInfo("/proc/cpuinfo", "Processor")
+            ?: "unknown"
+        val maxFreqKhz = readSysfsInt("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")
+        val curFreqKhz = (0 until coreCount).mapNotNull { i ->
+            readSysfsInt("/sys/devices/system/cpu/cpu$i/cpufreq/scaling_cur_freq")
+        }
+        val minFreqKhz = readSysfsInt("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq")
+        val gov = readSysfs("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor")
+        return DeviceStats.Cpu(
+            model = model,
+            coreCount = coreCount,
+            maxFreqMhz = maxFreqKhz / 1000,
+            currentFreqMhz = curFreqKhz.map { it / 1000 },
+            minFreqMhz = minFreqKhz / 1000,
+            governor = gov,
+        )
+    }
+
+    private fun collectRam(): DeviceStats.Ram {
+        val mi = ActivityManager.MemoryInfo()
+        am.getMemoryInfo(mi)
+        return DeviceStats.Ram(
+            totalMB = mi.totalMem / 1024 / 1024,
+            availableMB = mi.availMem / 1024 / 1024,
+            lowMemory = mi.lowMemory,
+            thresholdMB = mi.threshold / 1024 / 1024,
+        )
+    }
+
+    private fun collectHeap(): DeviceStats.Heap {
+        val rt = Runtime.getRuntime()
+        return DeviceStats.Heap(
+            maxMB = rt.maxMemory() / 1024 / 1024,
+            totalMB = rt.totalMemory() / 1024 / 1024,
+            freeMB = rt.freeMemory() / 1024 / 1024,
+        )
+    }
+
+    private fun collectStorage(): DeviceStats.Storage {
+        val ext = Environment.getDataDirectory()
+        val stat = StatFs(ext.path)
+        val blockSize = stat.blockSizeLong
+        return DeviceStats.Storage(
+            totalGB = (stat.blockCountLong * blockSize) / 1024 / 1024 / 1024,
+            availableGB = (stat.availableBlocksLong * blockSize) / 1024 / 1024 / 1024,
+            path = ext.absolutePath,
+        )
+    }
+
+    private fun collectGpu(): DeviceStats.Gpu {
+        val vendor = GLES20.glGetString(GLES20.GL_VENDOR) ?: "unknown"
+        val renderer = GLES20.glGetString(GLES20.GL_RENDERER) ?: "unknown"
+        val version = GLES20.glGetString(GLES20.GL_VERSION) ?: "unknown"
+        val extensions = try { GLES20.glGetString(GLES20.GL_EXTENSIONS)?.split(" ")?.size ?: 0 } catch (_: Exception) { 0 }
+        return DeviceStats.Gpu(
+            vendor = vendor,
+            renderer = renderer,
+            glVersion = version,
+            extensionCount = extensions,
+        )
+    }
+
+    private fun collectDisplay(): DeviceStats.Display {
+        val dm = wm.defaultDisplay
+        val metrics = android.util.DisplayMetrics()
+        @Suppress("DEPRECATION")
+        dm.getRealMetrics(metrics)
+        return DeviceStats.Display(
+            widthPx = metrics.widthPixels,
+            heightPx = metrics.heightPixels,
+            densityDpi = metrics.densityDpi,
+            density = metrics.density,
+            refreshRateHz = @Suppress("DEPRECATION") dm.refreshRate,
+            physicalSizeInches = run {
+                val wInches = metrics.widthPixels.toDouble() / metrics.xdpi
+                val hInches = metrics.heightPixels.toDouble() / metrics.ydpi
+                val diag = kotlin.math.sqrt(wInches * wInches + hInches * hInches)
+                String.format("%.1f", diag).toDouble()
+            },
+        )
+    }
+
+    private fun collectBattery(): DeviceStats.Battery {
+        // All detailed battery info comes from ACTION_BATTERY_CHANGED sticky intent
+        val batteryIntent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val level = batteryIntent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+        val scale = batteryIntent?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+        val pct = if (level >= 0 && scale > 0) (level * 100) / scale else bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+        val status = batteryIntent?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+        val voltage = batteryIntent?.getIntExtra(BatteryManager.EXTRA_VOLTAGE, 0) ?: 0
+        val temp = batteryIntent?.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, 0) ?: 0
+        return DeviceStats.Battery(
+            levelPercent = pct,
+            status = when (status) {
+                BatteryManager.BATTERY_STATUS_CHARGING -> "Charging"
+                BatteryManager.BATTERY_STATUS_DISCHARGING -> "Discharging"
+                BatteryManager.BATTERY_STATUS_FULL -> "Full"
+                BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "Not charging"
+                else -> "Unknown($status)"
+            },
+            voltageMv = voltage,
+            temperatureC = temp / 10.0,
+        )
+    }
+
+    private fun collectThermalZones(): List<DeviceStats.ThermalZone> {
+        val dir = File("/sys/class/thermal")
+        if (!dir.exists()) return emptyList()
+        return dir.listFiles()?.filter { it.name.startsWith("thermal_zone") }?.mapNotNull { zone ->
+            val type = readSysfs("${zone.absolutePath}/type") ?: return@mapNotNull null
+            val temp = readSysfsIntOrNull("${zone.absolutePath}/temp") ?: return@mapNotNull null
+            DeviceStats.ThermalZone(type = type, milliDegrees = temp)
+        }?.sortedBy { it.type } ?: emptyList()
+    }
+
+    private fun parseCpuInfo(path: String, key: String): String? {
+        return try {
+            File(path).readLines().firstOrNull { it.startsWith(key) }
+                ?.substringAfter(":")?.trim()
+        } catch (_: Exception) { null }
+    }
+
+    private fun readSysfs(path: String): String? {
+        return try { File(path).readText().trim().ifBlank { null } } catch (_: Exception) { null }
+    }
+
+    private fun readSysfsInt(path: String): Int {
+        return readSysfs(path)?.toIntOrNull() ?: 0
+    }
+
+    private fun readSysfsIntOrNull(path: String): Int? {
+        return readSysfs(path)?.toIntOrNull()
+    }
+}
+
+data class DeviceStats(
+    val device: Device,
+    val cpu: Cpu,
+    val ram: Ram,
+    val heap: Heap,
+    val storage: Storage,
+    val gpu: Gpu,
+    val display: Display,
+    val battery: Battery,
+    val thermalZones: List<ThermalZone>,
+) {
+    data class Device(
+        val manufacturer: String,
+        val model: String,
+        val hardware: String,
+        val board: String,
+        val abi: String,
+        val sdk: Int,
+        val release: String,
+        val securityPatch: String,
+    )
+
+    data class Cpu(
+        val model: String,
+        val coreCount: Int,
+        val maxFreqMhz: Int,
+        val currentFreqMhz: List<Int>,
+        val minFreqMhz: Int,
+        val governor: String?,
+    )
+
+    data class Ram(
+        val totalMB: Long,
+        val availableMB: Long,
+        val lowMemory: Boolean,
+        val thresholdMB: Long,
+    )
+
+    data class Heap(
+        val maxMB: Long,
+        val totalMB: Long,
+        val freeMB: Long,
+    )
+
+    data class Storage(
+        val totalGB: Long,
+        val availableGB: Long,
+        val path: String,
+    )
+
+    data class Gpu(
+        val vendor: String,
+        val renderer: String,
+        val glVersion: String,
+        val extensionCount: Int,
+    )
+
+    data class Display(
+        val widthPx: Int,
+        val heightPx: Int,
+        val densityDpi: Int,
+        val density: Float,
+        val refreshRateHz: Float,
+        val physicalSizeInches: Double,
+    )
+
+    data class Battery(
+        val levelPercent: Int,
+        val status: String,
+        val voltageMv: Int,
+        val temperatureC: Double,
+    )
+
+    data class ThermalZone(
+        val type: String,
+        val milliDegrees: Int,
+    ) {
+        val temperatureC: Double get() = milliDegrees / 1000.0
+    }
+
+    fun format(): String = buildString {
+        appendLine("== Device ==")
+        appendLine("  ${device.manufacturer} ${device.model} (${device.hardware})")
+        appendLine("  Board: ${device.board} | ABI: ${device.abi}")
+        appendLine("  Android ${device.release} (SDK ${device.sdk}) | Patch: ${device.securityPatch}")
+        appendLine()
+        appendLine("== CPU ==")
+        appendLine("  ${cpu.model}")
+        appendLine("  Cores: ${cpu.coreCount} | Gov: ${cpu.governor ?: "N/A"}")
+        appendLine("  Freq: ${cpu.minFreqMhz}–${cpu.maxFreqMhz} MHz")
+        if (cpu.currentFreqMhz.isNotEmpty()) {
+            appendLine("  Current: ${cpu.currentFreqMhz.joinToString(", ")} MHz")
+        }
+        appendLine()
+        appendLine("== RAM ==")
+        appendLine("  Total: ${ram.totalMB} MB | Available: ${ram.availableMB} MB | Low: ${ram.lowMemory}")
+        appendLine("  Threshold: ${ram.thresholdMB} MB")
+        appendLine()
+        appendLine("== Heap (JVM) ==")
+        appendLine("  Max: ${heap.maxMB} MB | Used: ${heap.totalMB - heap.freeMB} MB | Free: ${heap.freeMB} MB")
+        appendLine()
+        appendLine("== Storage ==")
+        appendLine("  Total: ${storage.totalGB} GB | Free: ${storage.availableGB} GB @ ${storage.path}")
+        appendLine()
+        appendLine("== GPU ==")
+        appendLine("  ${gpu.renderer} (${gpu.vendor})")
+        appendLine("  GL ${gpu.glVersion} | Extensions: ${gpu.extensionCount}")
+        appendLine()
+        appendLine("== Display ==")
+        appendLine("  ${display.widthPx}×${display.heightPx} @ ${display.refreshRateHz.toInt()} Hz")
+        appendLine("  Density: ${display.densityDpi} dpi (${display.density}x) | ${display.physicalSizeInches}\"")
+        appendLine()
+        appendLine("== Battery ==")
+        appendLine("  ${battery.levelPercent}% ${battery.status} | ${battery.voltageMv} mV | ${battery.temperatureC}°C")
+        if (thermalZones.isNotEmpty()) {
+            appendLine()
+            appendLine("== Thermal Zones ==")
+            thermalZones.forEach { tz ->
+                appendLine("  ${tz.type}: ${String.format("%.1f", tz.temperatureC)}°C")
+            }
+        }
+    }
+}

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/DeviceStatsCollector.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/DeviceStatsCollector.kt
@@ -48,7 +48,8 @@ class DeviceStatsCollector(private val context: Context) {
         val model = parseCpuInfo("/proc/cpuinfo", "Hardware")
             ?: parseCpuInfo("/proc/cpuinfo", "model name")
             ?: parseCpuInfo("/proc/cpuinfo", "Processor")
-            ?: "unknown"
+            ?: parseCpuInfo("/proc/cpuinfo", "CPU implementer")
+            ?: Build.HARDWARE
         val maxFreqKhz = readSysfsInt("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")
         val curFreqKhz = (0 until coreCount).mapNotNull { i ->
             readSysfsInt("/sys/devices/system/cpu/cpu$i/cpufreq/scaling_cur_freq")
@@ -110,21 +111,25 @@ class DeviceStatsCollector(private val context: Context) {
     }
 
     private fun collectDisplay(): DeviceStats.Display = try {
-        val dm = wm.defaultDisplay
-        val metrics = android.util.DisplayMetrics()
-        @Suppress("DEPRECATION")
-        dm.getRealMetrics(metrics)
+        val w = wm.currentWindowMetrics.bounds.width()
+        val h = wm.currentWindowMetrics.bounds.height()
+        val insets = wm.currentWindowMetrics.windowInsets
+        val density = context.resources.displayMetrics.densityDpi.toFloat()
+        val refreshRate = @Suppress("DEPRECATION") wm.defaultDisplay.refreshRate
         DeviceStats.Display(
-            widthPx = metrics.widthPixels,
-            heightPx = metrics.heightPixels,
-            densityDpi = metrics.densityDpi,
-            density = metrics.density,
-            refreshRateHz = @Suppress("DEPRECATION") dm.refreshRate,
+            widthPx = w,
+            heightPx = h,
+            densityDpi = density.toInt(),
+            density = context.resources.displayMetrics.density,
+            refreshRateHz = refreshRate,
             physicalSizeInches = run {
-                val wInches = metrics.widthPixels.toDouble() / metrics.xdpi
-                val hInches = metrics.heightPixels.toDouble() / metrics.ydpi
-                val diag = kotlin.math.sqrt(wInches * wInches + hInches * hInches)
-                String.format("%.1f", diag).toDouble()
+                val xdpi = context.resources.displayMetrics.xdpi
+                val ydpi = context.resources.displayMetrics.ydpi
+                if (xdpi > 0 && ydpi > 0) {
+                    val wIn = w.toDouble() / xdpi
+                    val hIn = h.toDouble() / ydpi
+                    String.format("%.1f", kotlin.math.sqrt(wIn * wIn + hIn * hIn)).toDouble()
+                } else 0.0
             },
         )
     } catch (_: Exception) {

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
@@ -31,6 +31,8 @@ import com.agent.code.core.lock.ActiveTaskLock
 import com.agent.code.core.lock.ConflictRisk
 import com.agent.code.core.lock.WorkspaceLockManager
 import com.agent.code.core.path.VirtualPath
+import com.agent.code.core.power.AndroidPowerGovernor
+import com.agent.code.core.power.StubPowerGovernor
 import com.agent.code.workspace.LibGit2Backend
 import com.agent.code.workspace.RealFileSystem
 import com.agent.code.workspace.WorktreeManager
@@ -257,6 +259,10 @@ private fun runM2Probe(): String = kotlinx.coroutines.runBlocking {
     val ioResult = kotlinx.coroutines.withContext(EnergyAwareDispatchers.EfficiencyIO) { " EfficiencyIO OK" }
     val computeResult = kotlinx.coroutines.withContext(EnergyAwareDispatchers.ComputeBurst) { " ComputeBurst OK" }
     log.add("Dispatchers:$ioResult,$computeResult")
+
+    // 8. Governor (stub for probe; AndroidPowerGovernor monitors battery/thermal on device)
+    val gov = StubPowerGovernor()
+    log.add("Governor: ${gov.currentProfile.value} (battery/thermal governor available via AndroidPowerGovernor)")
 
     log.joinToString("\n")
 }

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
@@ -23,9 +23,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
+import com.agent.code.core.concurrency.EnergyAwareDispatchers
 import com.agent.code.core.journal.AgentEvent
 import com.agent.code.core.journal.FileBackedWalStore
 import com.agent.code.core.journal.eventJson
+import com.agent.code.core.lock.ActiveTaskLock
+import com.agent.code.core.lock.ConflictRisk
+import com.agent.code.core.lock.WorkspaceLockManager
 import com.agent.code.core.path.VirtualPath
 import com.agent.code.workspace.LibGit2Backend
 import com.agent.code.workspace.RealFileSystem
@@ -65,6 +69,8 @@ fun ProbeDashboard(baseDir: String) {
                         results["LibGit2 JNI"] = git; expanded["LibGit2 JNI"] = true
                         val shizuku = withContext(Dispatchers.IO) { runShizukuProbe() }
                         results["Shizuku"] = shizuku; expanded["Shizuku"] = true
+                        val m2 = withContext(Dispatchers.IO) { runM2Probe() }
+                        results["M2 Concurrency"] = m2; expanded["M2 Concurrency"] = true
                         running = false
                     }
                 },
@@ -212,4 +218,45 @@ private fun runShizukuProbe(): String {
             appendLine("If Shevery is running, onServiceConnected will fire")
         }
     }
+}
+
+private fun runM2Probe(): String = kotlinx.coroutines.runBlocking {
+    val log = mutableListOf<String>()
+    val mgr = WorkspaceLockManager()
+
+    // 1. No collision on empty registry
+    val none = mgr.evaluateCollisionRisk(setOf(VirtualPath.of("/a.kt")), setOf("sym1"))
+    log.add("No collision (empty registry): ${none::class.simpleName}")
+
+    // 2. Register lock for task t1
+    mgr.waitForMaintenanceAndRegisterLock("t1",
+        ActiveTaskLock("t1", "agent/task-t1", setOf(VirtualPath.of("/a.kt")), setOf("symX")))
+
+    // 3. File overlap detection
+    val overlap = mgr.evaluateCollisionRisk(setOf(VirtualPath.of("/a.kt")), emptySet())
+    log.add("File overlap (t2 wants /a.kt): ${overlap::class.simpleName}" +
+        if (overlap is ConflictRisk.FileOverlapRequiresMerge) " — files: ${overlap.files}" else "")
+
+    // 4. Symbol collision detection
+    val collision = mgr.evaluateCollisionRisk(emptySet(), setOf("symX"))
+    log.add("Symbol collision (t2 wants symX): ${collision::class.simpleName}" +
+        if (collision is ConflictRisk.FatalSymbolCollision) " — symbols: ${collision.symbols}" else "")
+
+    // 5. Release + re-check
+    mgr.releaseLock("t1")
+    val afterRelease = mgr.evaluateCollisionRisk(setOf(VirtualPath.of("/a.kt")), emptySet())
+    log.add("After release: ${afterRelease::class.simpleName}")
+
+    // 6. Maintenance lock blocks new registrations
+    mgr.tryAcquireMaintenanceLock()
+    log.add("Maintenance lock acquired: activeLocks=${mgr.activeLockCount()}")
+    mgr.releaseMaintenanceLock()
+    log.add("Maintenance lock released")
+
+    // 7. Dispatcher smoke
+    val ioResult = kotlinx.coroutines.withContext(EnergyAwareDispatchers.EfficiencyIO) { " EfficiencyIO OK" }
+    val computeResult = kotlinx.coroutines.withContext(EnergyAwareDispatchers.ComputeBurst) { " ComputeBurst OK" }
+    log.add("Dispatchers:$ioResult,$computeResult")
+
+    log.joinToString("\n")
 }

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
@@ -265,7 +265,7 @@ private fun runM2Probe(governor: PowerGovernor = StubPowerGovernor()): String = 
     val govProfile = governor.currentProfile.value
     val govLine = if (governor is AndroidPowerGovernor) {
         val snap = governor.snapshot()
-        "Governor: ${snap.profile} | battery=${snap.batteryPercent}% | thermal=${snap.thermalLabel} | pluggedIn=${snap.pluggedIn}"
+        "Governor: ${snap.profile} | battery=${snap.batteryPercent}% | temp=${snap.temperatureCelsius}°C | thermal=${snap.thermalLabel} | pluggedIn=${snap.pluggedIn}"
     } else {
         "Governor: $govProfile (stub — no battery/thermal on host)"
     }

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
@@ -32,6 +32,7 @@ import com.agent.code.core.lock.ConflictRisk
 import com.agent.code.core.lock.WorkspaceLockManager
 import com.agent.code.core.path.VirtualPath
 import com.agent.code.core.power.AndroidPowerGovernor
+import com.agent.code.core.power.PowerGovernor
 import com.agent.code.core.power.StubPowerGovernor
 import com.agent.code.workspace.LibGit2Backend
 import com.agent.code.workspace.RealFileSystem
@@ -45,7 +46,7 @@ import kotlinx.coroutines.withContext
  * Unified probe dashboard: Run All, Copy All, collapsible per-probe sections.
  */
 @Composable
-fun ProbeDashboard(baseDir: String) {
+fun ProbeDashboard(baseDir: String, governor: PowerGovernor = StubPowerGovernor()) {
     val scope = rememberCoroutineScope()
     val clipboard = LocalClipboardManager.current
     val results = remember { mutableStateMapOf<String, String>() }
@@ -71,7 +72,7 @@ fun ProbeDashboard(baseDir: String) {
                         results["LibGit2 JNI"] = git; expanded["LibGit2 JNI"] = true
                         val shizuku = withContext(Dispatchers.IO) { runShizukuProbe() }
                         results["Shizuku"] = shizuku; expanded["Shizuku"] = true
-                        val m2 = withContext(Dispatchers.IO) { runM2Probe() }
+                        val m2 = withContext(Dispatchers.IO) { runM2Probe(governor) }
                         results["M2 Concurrency"] = m2; expanded["M2 Concurrency"] = true
                         running = false
                     }
@@ -222,7 +223,7 @@ private fun runShizukuProbe(): String {
     }
 }
 
-private fun runM2Probe(): String = kotlinx.coroutines.runBlocking {
+private fun runM2Probe(governor: PowerGovernor = StubPowerGovernor()): String = kotlinx.coroutines.runBlocking {
     val log = mutableListOf<String>()
     val mgr = WorkspaceLockManager()
 
@@ -260,9 +261,15 @@ private fun runM2Probe(): String = kotlinx.coroutines.runBlocking {
     val computeResult = kotlinx.coroutines.withContext(EnergyAwareDispatchers.ComputeBurst) { " ComputeBurst OK" }
     log.add("Dispatchers:$ioResult,$computeResult")
 
-    // 8. Governor (stub for probe; AndroidPowerGovernor monitors battery/thermal on device)
-    val gov = StubPowerGovernor()
-    log.add("Governor: ${gov.currentProfile.value} (battery/thermal governor available via AndroidPowerGovernor)")
+    // 8. Governor — real snapshot from device
+    val govProfile = governor.currentProfile.value
+    val govLine = if (governor is AndroidPowerGovernor) {
+        val snap = governor.snapshot()
+        "Governor: ${snap.profile} | battery=${snap.batteryPercent}% | thermal=${snap.thermalLabel} | pluggedIn=${snap.pluggedIn}"
+    } else {
+        "Governor: $govProfile (stub — no battery/thermal on host)"
+    }
+    log.add(govLine)
 
     log.joinToString("\n")
 }

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.agent.code.core.concurrency.EnergyAwareDispatchers
@@ -39,6 +41,8 @@ import com.agent.code.workspace.RealFileSystem
 import com.agent.code.workspace.WorktreeManager
 import java.io.File
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -49,12 +53,25 @@ import kotlinx.coroutines.withContext
 fun ProbeDashboard(baseDir: String, governor: PowerGovernor = StubPowerGovernor()) {
     val scope = rememberCoroutineScope()
     val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
     val results = remember { mutableStateMapOf<String, String>() }
     val expanded = remember { mutableStateMapOf<String, Boolean>() }
     var running by remember { mutableStateOf(false) }
+    var deviceStatsText by remember { mutableStateOf<String?>(null) }
 
     fun isExpanded(key: String) = expanded[key] == true
     fun toggle(key: String) { expanded[key] = !isExpanded(key) }
+
+    // Live-refresh device stats every 10s while section is expanded
+    val collector = remember { DeviceStatsCollector(context) }
+    LaunchedEffect(isExpanded("Device Stats")) {
+        if (!isExpanded("Device Stats")) return@LaunchedEffect
+        while (isActive) {
+            val stats = withContext(Dispatchers.IO) { collector.collect().format() }
+            deviceStatsText = stats
+            delay(10_000)
+        }
+    }
 
     Column(
         modifier = Modifier.fillMaxWidth().padding(16.dp),
@@ -74,6 +91,9 @@ fun ProbeDashboard(baseDir: String, governor: PowerGovernor = StubPowerGovernor(
                         results["Shizuku"] = shizuku; expanded["Shizuku"] = true
                         val m2 = withContext(Dispatchers.IO) { runM2Probe(governor) }
                         results["M2 Concurrency"] = m2; expanded["M2 Concurrency"] = true
+                        val stats = withContext(Dispatchers.IO) { collector.collect().format() }
+                        deviceStatsText = stats
+                        results["Device Stats"] = stats; expanded["Device Stats"] = true
                         running = false
                     }
                 },
@@ -99,6 +119,7 @@ fun ProbeDashboard(baseDir: String, governor: PowerGovernor = StubPowerGovernor(
         }
 
         results.forEach { (name, log) ->
+            val displayText = if (name == "Device Stats") (deviceStatsText ?: log) else log
             HorizontalDivider()
             Row(
                 modifier = Modifier.fillMaxWidth().clickable { toggle(name) },
@@ -111,7 +132,7 @@ fun ProbeDashboard(baseDir: String, governor: PowerGovernor = StubPowerGovernor(
                 )
             }
             AnimatedVisibility(isExpanded(name)) {
-                Text(log, modifier = Modifier.padding(start = 8.dp))
+                Text(displayText, modifier = Modifier.padding(start = 8.dp))
             }
         }
     }

--- a/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
+++ b/shared/src/androidMain/kotlin/com/agent/code/ui/ProbeDashboard.kt
@@ -67,7 +67,11 @@ fun ProbeDashboard(baseDir: String, governor: PowerGovernor = StubPowerGovernor(
     LaunchedEffect(isExpanded("Device Stats")) {
         if (!isExpanded("Device Stats")) return@LaunchedEffect
         while (isActive) {
-            val stats = withContext(Dispatchers.IO) { collector.collect().format() }
+            val stats = try {
+                withContext(Dispatchers.IO) { collector.collect().format() }
+            } catch (e: Exception) {
+                "Device Stats error: ${e.message}"
+            }
             deviceStatsText = stats
             delay(10_000)
         }

--- a/shared/src/commonMain/kotlin/com/agent/code/core/fsm/AgentOrchestrator.kt
+++ b/shared/src/commonMain/kotlin/com/agent/code/core/fsm/AgentOrchestrator.kt
@@ -1,8 +1,7 @@
 package com.agent.code.core.fsm
 
-import com.agent.code.core.lock.ConflictRisk
-import com.agent.code.core.lock.ExecutionPermit
 import com.agent.code.core.lock.SemanticConflictFunnel
+import com.agent.code.core.lock.SemanticVerificationResult
 import com.agent.code.core.lock.TaskLockCoordinator
 import com.agent.code.core.path.VirtualPath
 import com.agent.code.core.journal.AgentEvent
@@ -10,6 +9,8 @@ import com.agent.code.core.journal.AgentEventJournal
 import com.agent.code.core.journal.LogEntry
 import com.agent.code.core.journal.TelemetryEngine
 import com.agent.code.core.policy.AutonomyPolicy
+import com.agent.code.core.power.PowerGovernor
+import com.agent.code.core.power.StubPowerGovernor
 import com.agent.code.core.tools.ToolResult
 import com.agent.code.mcp.McpHost
 import kotlinx.coroutines.delay
@@ -22,19 +23,14 @@ sealed interface StepResult {
     data class FatalError(val reason: String) : StepResult
 }
 
-enum class OperatingProfile {
-    TURBO_PLUGGED,
-    BALANCED_BATTERY,
-    ECO_PRESERVATION
-}
-
 class AgentOrchestrator(
     private val journal: AgentEventJournal,
     private val policy: AutonomyPolicy,
     private val mcp: McpHost,
     private val telemetry: TelemetryEngine,
     private val lockCoordinator: TaskLockCoordinator? = null,
-    private val funnel: SemanticConflictFunnel? = null
+    private val funnel: SemanticConflictFunnel? = null,
+    private val governor: PowerGovernor = StubPowerGovernor()
 ) {
     private var seq = 0L
     private fun nextId(): Long = ++seq
@@ -65,7 +61,7 @@ class AgentOrchestrator(
 
     // --- Step-based execution API (M2) ---
 
-    suspend fun executeSingleStep(taskId: String, profile: OperatingProfile = OperatingProfile.TURBO_PLUGGED): StepResult {
+    suspend fun executeSingleStep(taskId: String): StepResult {
         val currentState = journal.recoverState(taskId)
         return when (currentState) {
             is AgentState.Success -> StepResult.TaskFinished
@@ -79,9 +75,14 @@ class AgentOrchestrator(
         }
     }
 
-    suspend fun executeStepPaced(taskId: String, profile: OperatingProfile = OperatingProfile.BALANCED_BATTERY): StepResult {
-        val result = executeSingleStep(taskId, profile)
-        when (profile) {
+    /**
+     * Execute one step with pacing driven by [governor].
+     * Reads the current [OperatingProfile] from governor and applies the
+     * appropriate delay after the step completes.
+     */
+    suspend fun executeStepPaced(taskId: String): StepResult {
+        val result = executeSingleStep(taskId)
+        when (governor.currentProfile.value) {
             OperatingProfile.TURBO_PLUGGED -> { /* no delay */ }
             OperatingProfile.BALANCED_BATTERY -> delay(50L)
             OperatingProfile.ECO_PRESERVATION -> delay(500L)
@@ -92,13 +93,13 @@ class AgentOrchestrator(
     suspend fun executeStepsUntilDone(
         taskId: String,
         toolCalls: List<ToolCall>,
-        profile: OperatingProfile = OperatingProfile.TURBO_PLUGGED,
         maxSteps: Int = 50
     ): StepResult {
         var toolIndex = 0
         var steps = 0
         while (steps < maxSteps) {
             val state = recover(taskId)
+            val profile = governor.currentProfile.value
             when (state) {
                 is AgentState.Success, is AgentState.Error -> return StepResult.TaskFinished
                 is AgentState.Idle -> return StepResult.TaskFinished
@@ -125,7 +126,7 @@ class AgentOrchestrator(
                 }
                 is AgentState.Verifying -> {
                     val verification = funnel?.verifyBranchIntegration("agent/task-$taskId", emptyList())
-                    if (verification is com.agent.code.core.lock.SemanticVerificationResult.Failed) {
+                    if (verification is SemanticVerificationResult.Failed) {
                         return StepResult.FatalError(verification.reason)
                     }
                     succeed(taskId, "completed")
@@ -140,8 +141,10 @@ class AgentOrchestrator(
                 }
             }
             steps++
-            if (profile != OperatingProfile.TURBO_PLUGGED) {
-                delay(if (profile == OperatingProfile.BALANCED_BATTERY) 50L else 500L)
+            when (profile) {
+                OperatingProfile.TURBO_PLUGGED -> { /* no delay */ }
+                OperatingProfile.BALANCED_BATTERY -> delay(50L)
+                OperatingProfile.ECO_PRESERVATION -> delay(500L)
             }
         }
         return StepResult.FatalError("Max steps ($maxSteps) exhausted without completion")
@@ -151,7 +154,6 @@ class AgentOrchestrator(
 
     private fun processPlanningStep(taskId: String, state: AgentState.Planning): StepResult {
         // DEFERRED: LLM integration will generate tool calls here.
-        // For now, return pending so the caller knows more work is needed.
         return StepResult.StepCompletedMoreWorkPending
     }
 
@@ -167,9 +169,9 @@ class AgentOrchestrator(
     private suspend fun processVerificationStep(taskId: String): StepResult {
         val verification = funnel?.verifyBranchIntegration("agent/task-$taskId", emptyList())
         return when (verification) {
-            is com.agent.code.core.lock.SemanticVerificationResult.Failed ->
+            is SemanticVerificationResult.Failed ->
                 StepResult.FatalError("Verification failed: ${verification.reason}")
-            is com.agent.code.core.lock.SemanticVerificationResult.EscalationRequired ->
+            is SemanticVerificationResult.EscalationRequired ->
                 StepResult.FatalError("Escalation required: ${verification.ambiguousInvariants}")
             else -> StepResult.StepCompletedMoreWorkPending
         }

--- a/shared/src/commonMain/kotlin/com/agent/code/core/fsm/OperatingProfile.kt
+++ b/shared/src/commonMain/kotlin/com/agent/code/core/fsm/OperatingProfile.kt
@@ -1,0 +1,14 @@
+package com.agent.code.core.fsm
+
+/**
+ * Thermal/power operating profile (§2.3 Development_Doc.md).
+ * Drives concurrency limits and pacing in AgentOrchestrator.
+ */
+enum class OperatingProfile {
+    /** Charging and cool: max concurrency, no pacing delay. */
+    TURBO_PLUGGED,
+    /** Battery >20% and normal temp: 1-2 concurrent agents, 50ms pacing. */
+    BALANCED_BATTERY,
+    /** Battery <20% or thermal severe: serialize steps, 500ms pacing. */
+    ECO_PRESERVATION
+}

--- a/shared/src/commonMain/kotlin/com/agent/code/core/lock/SemanticConflictFunnel.kt
+++ b/shared/src/commonMain/kotlin/com/agent/code/core/lock/SemanticConflictFunnel.kt
@@ -1,6 +1,7 @@
 package com.agent.code.core.lock
 
 import com.agent.code.core.path.VirtualPath
+import com.agent.code.workspace.ProcessRunner
 
 sealed interface SemanticVerificationResult {
     object Passed : SemanticVerificationResult
@@ -13,18 +14,15 @@ sealed interface SemanticVerificationResult {
  *
  * Tier 1 (implemented): Pre-write collision check via WorkspaceLockManager.
  * Tier 2 (deferred): Backward AST Slicing — requires TreeSitter CInterop.
- * Tier 3 (deferred): Bounded Mutation Testing on impact set — requires TreeSitter + test runner.
- * Tier 4 (deferred): Targeted test execution — requires TreeSitter symbol index.
- *
- * Tiers 2-4 are blocked on TreeSitter native integration (future milestone).
- * This stub provides the interface contract and delegates Tier 1 to the lock manager.
+ * Tier 3 (implemented): Bounded test execution on changed files via ProcessRunner.
+ * Tier 4 (deferred): Targeted test selection via TreeSitter symbol index.
  */
 class SemanticConflictFunnel(
-    private val lockManager: WorkspaceLockManager
+    private val lockManager: WorkspaceLockManager,
+    private val testRunner: ProcessRunner? = null
 ) {
     /**
      * Tier 1: Check for pre-write collisions against active locks.
-     * Returns ConflictRisk.None if no contention, or the collision type.
      */
     fun checkPreWriteCollision(taskId: String, requestedSymbols: Set<String>): ConflictRisk {
         return lockManager.evaluateCollisionRisk(
@@ -34,31 +32,48 @@ class SemanticConflictFunnel(
     }
 
     /**
-     * Tier 2-4: Verify branch integration after code changes.
+     * Verify branch integration after code changes.
      *
-     * DEFERRED — requires TreeSitter CInterop for:
-     * - Tier 2: computeImpactedSymbolSlice(changedFiles) — AST-based change impact analysis
-     * - Tier 3: findTargetedTestsForSlice(impactedSymbols) — bounded mutation testing
-     * - Tier 4: execute targeted tests via ProcessRunner
-     *
-     * Current stub: returns Passed (no-op) until TreeSitter is available.
-     * When TreeSitter lands, this will:
-     *   1. Parse changed files into AST
-     *   2. Compute impacted symbol slice (callers, dependents)
-     *   3. Find targeted tests for the slice
-     *   4. Execute those tests via ProcessRunner
-     *   5. Return Passed/Failed/EscalationRequired
+     * Tier 1: lock-based collision (via checkPreWriteCollision, caller handles).
+     * Tier 2: AST slicing — DEFERRED (TreeSitter CInterop needed).
+     * Tier 3: Run `gradle test` on changed files. If no test runner injected, passes.
+     * Tier 4: Targeted test selection — DEFERRED (needs TreeSitter symbol index).
      */
     suspend fun verifyBranchIntegration(
         branchName: String,
         changedFiles: List<VirtualPath>
     ): SemanticVerificationResult {
-        // DEFERRED: TreeSitter CInterop not yet available.
-        // When ready, replace with:
-        //   val impactedSymbols = treeSitter.computeImpactedSymbolSlice(changedFiles)
-        //   val targetedTests = treeSitter.findTargetedTestsForSlice(impactedSymbols)
-        //   val testResult = testRunner.execute(ProcessConfiguration("gradle", listOf("test", ...)))
-        //   return if (testResult.isSuccess) Passed else Failed(testResult.stderr)
-        return SemanticVerificationResult.Passed
+        if (changedFiles.isEmpty()) return SemanticVerificationResult.Passed
+
+        // Tier 3: Run tests via ProcessRunner.
+        // Without TreeSitter (Tier 2/4), we run the full test suite — not targeted.
+        // This is conservative but catches real regressions.
+        val runner = testRunner ?: return SemanticVerificationResult.Passed
+
+        // Extract test file paths from changed files (heuristic: *Test.kt, *Spec.kt)
+        val testFiles = changedFiles.filter { path ->
+            val name = path.rawPath.substringAfterLast('/')
+            name.endsWith("Test.kt") || name.endsWith("Spec.kt") || name.endsWith("Tests.kt")
+        }
+
+        val testArgs = if (testFiles.isNotEmpty()) {
+            // Targeted: run specific test classes
+            val classes = testFiles.map { path ->
+                val name = path.rawPath.substringAfterLast('/').removeSuffix(".kt")
+                name
+            }
+            listOf("test", "--tests", classes.joinToString(","))
+        } else {
+            // No test files in changeset — run full suite
+            listOf("test")
+        }
+
+        val result = runner.run(listOf("gradle") + testArgs)
+        return if (result.isSuccess) {
+            SemanticVerificationResult.Passed
+        } else {
+            val stderr = result.exceptionOrNull()?.message ?: "test execution failed"
+            SemanticVerificationResult.Failed("Targeted tests failed: $stderr")
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/agent/code/core/power/PowerGovernor.kt
+++ b/shared/src/commonMain/kotlin/com/agent/code/core/power/PowerGovernor.kt
@@ -1,0 +1,15 @@
+package com.agent.code.core.power
+
+import com.agent.code.core.fsm.OperatingProfile
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Platform-adaptive power governor (§2.3 Development_Doc.md).
+ * Monitors battery/thermal state and exposes an [OperatingProfile] via StateFlow.
+ *
+ * Host/JVM: always returns [OperatingProfile.BALANCED_BATTERY].
+ * Android: observes BroadcastReceiver (battery) + PowerManager thermal listener.
+ */
+interface PowerGovernor {
+    val currentProfile: StateFlow<OperatingProfile>
+}

--- a/shared/src/commonMain/kotlin/com/agent/code/core/power/StubPowerGovernor.kt
+++ b/shared/src/commonMain/kotlin/com/agent/code/core/power/StubPowerGovernor.kt
@@ -1,0 +1,13 @@
+package com.agent.code.core.power
+
+import com.agent.code.core.fsm.OperatingProfile
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Host/JVM stub governor — always BALANCED. No battery/thermal signals on JVM.
+ */
+class StubPowerGovernor : PowerGovernor {
+    override val currentProfile: StateFlow<OperatingProfile> =
+        MutableStateFlow(OperatingProfile.BALANCED_BATTERY)
+}


### PR DESCRIPTION
Lands the remaining M2 commits that were pushed after PR #29 merged:

- AdaptivePowerGovernor (sysfs thermal + battery BroadcastReceiver)
- SemanticConflictFunnel Tier 3 (targeted test runner)
- Governor wiring into AgentOrchestrator
- M2 concurrency probe in ProbeDashboard
- DeviceStatsCollector (RAM, CPU, storage, GPU, display, battery, thermal)
- Device stats probe with 10s refresh
- Crash fix: GLES20 SIGSEGV on Adreno (replaced with ActivityManager)
- Display fix: WindowMetrics for Android 16
- CPU model fallback to Build.HARDWARE