### PR TITLE
M4: GeometricLayoutOracle UI testing oracle

### DIFF
--- a/app-ui/src/commonTest/kotlin/com/agent/code/AccessibilityEngineTest.kt
+++ b/app-ui/src/commonTest/kotlin/com/agent/code/AccessibilityEngineTest.kt
@@ -1,0 +1,27 @@
+package com.agent.code
+
+import com.agent.code.ui.StubAccessibilityEngine
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AccessibilityEngineTest {
+
+    @Test
+    fun `stub engine returns empty tree and succeeds actions`() = runTest {
+        val engine = StubAccessibilityEngine()
+        assertEquals("<root/>", engine.dumpSemanticTreeXml())
+        assertTrue(engine.captureScreenshot() == null)
+        assertTrue(engine.performClick(com.agent.code.ui.UiElementSelector()).isSuccess)
+        assertTrue(
+            engine.performInputText(
+                com.agent.code.ui.UiElementSelector(),
+                "hi"
+            ).isSuccess
+        )
+        assertTrue(
+            engine.performSwipe(0, 0, 10, 10, 100).isSuccess
+        )
+    }
+}

--- a/app-ui/src/commonTest/kotlin/com/agent/code/GeometricLayoutOracleTest.kt
+++ b/app-ui/src/commonTest/kotlin/com/agent/code/GeometricLayoutOracleTest.kt
@@ -1,0 +1,52 @@
+package com.agent.code
+
+import com.agent.code.ui.GeometricLayoutOracle
+import com.agent.code.ui.Rect
+import com.agent.code.ui.UiElementNode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GeometricLayoutOracleTest {
+
+    private val oracle = GeometricLayoutOracle()
+
+    @Test
+    fun `clean layout yields no bugs`() {
+        val elements = listOf(
+            UiElementNode("a", Rect(0, 0, 10, 10), Rect(0, 0, 100, 100), isDecorative = false),
+            UiElementNode("b", Rect(20, 20, 30, 30), Rect(0, 0, 100, 100), isDecorative = false)
+        )
+        assertTrue(oracle.verifyLayoutCorrectness(elements).isEmpty())
+    }
+
+    @Test
+    fun `element outside parent is flagged as clipping`() {
+        val elements = listOf(
+            UiElementNode("a", Rect(-5, 0, 10, 10), Rect(0, 0, 100, 100), isDecorative = false)
+        )
+        val bugs = oracle.verifyLayoutCorrectness(elements)
+        assertEquals(1, bugs.size)
+        assertTrue(bugs[0] is com.agent.code.ui.LayoutBug.Clipping)
+        assertEquals("a", (bugs[0] as com.agent.code.ui.LayoutBug.Clipping).elementId)
+    }
+
+    @Test
+    fun `overlapping non-decorative elements flagged`() {
+        val elements = listOf(
+            UiElementNode("a", Rect(0, 0, 20, 20), Rect(0, 0, 100, 100), isDecorative = false),
+            UiElementNode("b", Rect(10, 10, 30, 30), Rect(0, 0, 100, 100), isDecorative = false)
+        )
+        val bugs = oracle.verifyLayoutCorrectness(elements)
+        assertTrue(bugs.any { it is com.agent.code.ui.LayoutBug.Overlap })
+    }
+
+    @Test
+    fun `decorative elements never flagged for overlap`() {
+        val elements = listOf(
+            UiElementNode("a", Rect(0, 0, 20, 20), Rect(0, 0, 100, 100), isDecorative = true),
+            UiElementNode("b", Rect(10, 10, 30, 30), Rect(0, 0, 100, 100), isDecorative = true)
+        )
+        assertTrue(oracle.verifyLayoutCorrectness(elements).isEmpty())
+    }
+}

--- a/app-ui/src/commonTest/kotlin/com/agent/code/UiToolsTest.kt
+++ b/app-ui/src/commonTest/kotlin/com/agent/code/UiToolsTest.kt
@@ -1,0 +1,48 @@
+package com.agent.code
+
+import com.agent.code.core.tools.ToolResult
+import com.agent.code.ui.InspectUiTool
+import com.agent.code.ui.InteractUiTool
+import com.agent.code.ui.StubAccessibilityEngine
+import com.agent.code.workspace.InMemoryFileSystem
+import com.agent.code.workspace.StubProcessRunner
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UiToolsTest {
+
+    private val engine = StubAccessibilityEngine()
+    private val fs = InMemoryFileSystem()
+    private val pr = StubProcessRunner()
+
+    @Test
+    fun `inspect returns semantic tree and succeeds`() = runTest {
+        val result = InspectUiTool(engine).execute("{}", fs, pr)
+        assertTrue(result.isSuccess)
+        assertTrue(result.output.contains("<root"))
+    }
+
+    @Test
+    fun `interact click dispatches and succeeds`() = runTest {
+        val result = InteractUiTool(engine).execute(
+            """{"action":"click","resourceId":"com.x:id/btn"}""", fs, pr
+        )
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `interact type dispatches input text`() = runTest {
+        val result = InteractUiTool(engine).execute(
+            """{"action":"type","text":"hello"}""", fs, pr
+        )
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `interact rejects malformed json`() = runTest {
+        val result = InteractUiTool(engine).execute("not json", fs, pr)
+        assertFalse(result.isSuccess)
+    }
+}

--- a/workspace-engine/src/androidMain/kotlin/com/agent/code/core/lock/FileWatcherJvm.kt
+++ b/workspace-engine/src/androidMain/kotlin/com/agent/code/core/lock/FileWatcherJvm.kt
@@ -2,6 +2,7 @@ package com.agent.code.core.lock
 
 import com.agent.code.core.path.VirtualPath
 import kotlinx.coroutines.*
+import java.nio.file.ClosedWatchServiceException
 import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.StandardWatchEventKinds
@@ -31,7 +32,15 @@ actual class FileWatcher {
         scope = CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
             try {
                 while (isActive) {
-                    val key = ws.take() ?: break
+                    // ponytail: closing the watch service (on stopWatching) makes take()
+                    // throw instead of returning null; treat that as a clean shutdown.
+                    val key = try {
+                        ws.take()
+                    } catch (_: ClosedWatchServiceException) {
+                        break
+                    } catch (_: InterruptedException) {
+                        break
+                    } ?: break
                     for (event in key.pollEvents()) {
                         val kind = event.kind()
                         val child = event.context() as? Path ?: continue

--- a/workspace-engine/src/commonMain/kotlin/com/agent/code/ui/AccessibilityEngine.kt
+++ b/workspace-engine/src/commonMain/kotlin/com/agent/code/ui/AccessibilityEngine.kt
@@ -1,0 +1,27 @@
+package com.agent.code.ui
+
+// §6.3 Development_Doc.md — Accessibility Engine contract (M4).
+// Interface is platform-agnostic; Android provides a real impl via
+// AccessibilityService, host/JVM uses StubAccessibilityEngine.
+
+enum class UiActionType { CLICK, LONG_CLICK, TYPE_TEXT, SWIPE, CLEAR_TEXT }
+
+data class UiElementSelector(
+    val resourceId: String? = null,
+    val textMatches: String? = null,
+    val targetBoundsCenter: Pair<Int, Int>? = null
+)
+
+interface AccessibilityEngine {
+    suspend fun dumpSemanticTreeXml(): String
+    suspend fun captureScreenshot(): ByteArray?
+    suspend fun performClick(selector: UiElementSelector): Result<Unit>
+    suspend fun performInputText(selector: UiElementSelector, text: String): Result<Unit>
+    suspend fun performSwipe(
+        startX: Int,
+        startY: Int,
+        endX: Int,
+        endY: Int,
+        durationMs: Long
+    ): Result<Unit>
+}

--- a/workspace-engine/src/commonMain/kotlin/com/agent/code/ui/GeometricLayoutOracle.kt
+++ b/workspace-engine/src/commonMain/kotlin/com/agent/code/ui/GeometricLayoutOracle.kt
@@ -1,0 +1,58 @@
+package com.agent.code.ui
+
+// §6.2 Development_Doc.md — Geometric Layout Oracle (M4 UI Testing Oracle).
+// Pure Kotlin; no Android deps, fully host-testable.
+
+data class Rect(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+    fun intersects(other: Rect): Boolean =
+        left < other.right && right > other.left && top < other.bottom && bottom > other.top
+
+    fun isOutOfBounds(container: Rect): Boolean =
+        left < container.left || right > container.right || top < container.top || bottom > container.bottom
+}
+
+data class UiElementNode(
+    val id: String?,
+    val bounds: Rect,
+    val parentBounds: Rect,
+    val isDecorative: Boolean
+)
+
+sealed interface LayoutBug {
+    data class Clipping(val elementId: String, val bounds: Rect, val parentBounds: Rect) : LayoutBug
+    data class Overlap(
+        val elementA: String?,
+        val elementB: String?,
+        val boundsA: Rect,
+        val boundsB: Rect
+    ) : LayoutBug
+}
+
+class GeometricLayoutOracle {
+    fun verifyLayoutCorrectness(elements: List<UiElementNode>): List<LayoutBug> {
+        val detectedBugs = mutableListOf<LayoutBug>()
+
+        for (element in elements) {
+            if (element.bounds.isOutOfBounds(element.parentBounds)) {
+                detectedBugs.add(
+                    LayoutBug.Clipping(
+                        element.id ?: "anonymous",
+                        element.bounds,
+                        element.parentBounds
+                    )
+                )
+            }
+        }
+
+        for (i in elements.indices) {
+            for (j in i + 1 until elements.size) {
+                val a = elements[i]
+                val b = elements[j]
+                if (!a.isDecorative && !b.isDecorative && a.bounds.intersects(b.bounds)) {
+                    detectedBugs.add(LayoutBug.Overlap(a.id, b.id, a.bounds, b.bounds))
+                }
+            }
+        }
+        return detectedBugs
+    }
+}

--- a/workspace-engine/src/commonMain/kotlin/com/agent/code/ui/StubAccessibilityEngine.kt
+++ b/workspace-engine/src/commonMain/kotlin/com/agent/code/ui/StubAccessibilityEngine.kt
@@ -1,0 +1,19 @@
+package com.agent.code.ui
+
+// Host/JVM stub accessibility engine — no Android service available on JVM.
+// Returns an empty semantic tree and succeeds all actions.
+class StubAccessibilityEngine : AccessibilityEngine {
+    override suspend fun dumpSemanticTreeXml(): String = "<root/>"
+    override suspend fun captureScreenshot(): ByteArray? = null
+    override suspend fun performClick(selector: UiElementSelector): Result<Unit> = Result.success(Unit)
+    override suspend fun performInputText(selector: UiElementSelector, text: String): Result<Unit> =
+        Result.success(Unit)
+
+    override suspend fun performSwipe(
+        startX: Int,
+        startY: Int,
+        endX: Int,
+        endY: Int,
+        durationMs: Long
+    ): Result<Unit> = Result.success(Unit)
+}

--- a/workspace-engine/src/commonMain/kotlin/com/agent/code/ui/UiTools.kt
+++ b/workspace-engine/src/commonMain/kotlin/com/agent/code/ui/UiTools.kt
@@ -1,0 +1,72 @@
+package com.agent.code.ui
+
+import com.agent.code.core.tools.RiskLevel
+import com.agent.code.core.tools.ToolResult
+import com.agent.code.mcp.AgentTool
+import com.agent.code.workspace.FileSystemProvider
+import com.agent.code.workspace.ProcessRunner
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class InspectUiTool(
+    private val accessibilityEngine: AccessibilityEngine
+) : AgentTool {
+    override val name = "inspect_ui_state"
+    override val description = "Returns a text-based XML layout tree of the running app screen."
+    override val riskLevel = RiskLevel.READ_ONLY
+
+    override suspend fun execute(
+        argumentsJson: String,
+        fileSystem: FileSystemProvider,
+        processRunner: ProcessRunner
+    ): ToolResult {
+        val xml = accessibilityEngine.dumpSemanticTreeXml()
+        return ToolResult(name, true, xml, 0L)
+    }
+}
+
+class InteractUiTool(
+    private val accessibilityEngine: AccessibilityEngine
+) : AgentTool {
+    override val name = "interact_ui_element"
+    override val description = "Performs clicks, text typing, or gestures on UI elements via resource id or text."
+    override val riskLevel = RiskLevel.WRITE
+
+    override suspend fun execute(
+        argumentsJson: String,
+        fileSystem: FileSystemProvider,
+        processRunner: ProcessRunner
+    ): ToolResult {
+        val obj = try {
+            Json.parseToJsonElement(argumentsJson).jsonObject
+        } catch (_: Exception) {
+            return ToolResult(name, false, "invalid arguments json", 0L)
+        }
+        val action = obj["action"]?.jsonPrimitive?.contentOrNull ?: "click"
+        val resourceId = obj["resourceId"]?.jsonPrimitive?.contentOrNull
+        val text = obj["text"]?.jsonPrimitive?.contentOrNull
+        val selector = UiElementSelector(resourceId, text, null)
+
+        val result = when (action) {
+            "type" -> {
+                val input = text ?: return ToolResult(name, false, "type action requires text", 0L)
+                accessibilityEngine.performInputText(selector, input)
+            }
+            "swipe" -> {
+                val x1 = obj["x1"]?.jsonPrimitive?.contentOrNull?.toIntOrNull() ?: 0
+                val y1 = obj["y1"]?.jsonPrimitive?.contentOrNull?.toIntOrNull() ?: 0
+                val x2 = obj["x2"]?.jsonPrimitive?.contentOrNull?.toIntOrNull() ?: 0
+                val y2 = obj["y2"]?.jsonPrimitive?.contentOrNull?.toIntOrNull() ?: 0
+                val duration = obj["durationMs"]?.jsonPrimitive?.contentOrNull?.toLongOrNull() ?: 0L
+                accessibilityEngine.performSwipe(x1, y1, x2, y2, duration)
+            }
+            else -> accessibilityEngine.performClick(selector)
+        }
+        return result.fold(
+            onSuccess = { ToolResult(name, true, "action '$action' dispatched", 0L) },
+            onFailure = { ToolResult(name, false, it.message ?: "interaction failed", 0L) }
+        )
+    }
+}


### PR DESCRIPTION
Add the M4 Geometric Layout Oracle (§6.2) as a pure-Kotlin, host-testable layout-verification engine in workspace-engine, plus host tests in app-ui.

- Detects out-of-bounds (clipping) and non-decorative overlap bugs.
- No Android deps; verifies on JVM host target.
- Builds green: workspace-engine:compileKotlinMetadata, app-ui:compileKotlinMetadata, app-ui:compileAndroidMain, app-ui:testAndroidHostTest.