### PR TITLE
feat: M5.2 + M5.3 + CodeRabbit fixes

### DIFF
--- a/agent-core/src/androidMain/kotlin/com/agent/code/core/power/AndroidPowerGovernor.kt
+++ b/agent-core/src/androidMain/kotlin/com/agent/code/core/power/AndroidPowerGovernor.kt
@@ -108,8 +108,9 @@ class AndroidPowerGovernor(private val context: Context) : PowerGovernor {
                 } catch (_: Exception) { return@forEach }
                 if (!isRealTempSensor(type) || raw <= 0f) return@forEach
                 val celsius = when {
-                    raw > 10000 -> raw / 1000f
-                    raw in 500f..10000f -> raw / 10f
+                    raw >= 10000f -> raw / 1000f
+                    raw >= 100f -> raw / 10f
+                    raw >= 20f -> raw
                     else -> return@forEach
                 }
                 if (celsius > max) {

--- a/agent-core/src/commonMain/kotlin/com/agent/code/core/fsm/AgentOrchestrator.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/core/fsm/AgentOrchestrator.kt
@@ -129,7 +129,7 @@ class AgentOrchestrator(
                             if (permit != null) lockCoordinator.releaseTaskExecutionPermit(taskId, emptySet())
                         }
                     } else if (state is AgentState.ExecutingTool) {
-                        // ExecutingTool with no more tool calls — shouldn't happen, but handle gracefully
+                        return StepResult.FatalError("ExecutingTool persisted with no pending tool calls — unrecoverable state")
                     } else {
                         return StepResult.TaskFinished
                     }

--- a/agent-core/src/commonMain/kotlin/com/agent/code/core/tools/CircuitBreaker.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/core/tools/CircuitBreaker.kt
@@ -3,3 +3,41 @@ package com.agent.code.core.tools
 class CircuitBreaker(private val openFor: Set<String> = emptySet()) {
     fun isOpen(providerId: String): Boolean = providerId in openFor
 }
+
+data class TaskSafetyBudget(
+    val maxCostUsd: Double = 1.50,
+    val maxToolCallsCount: Int = 40,
+    val maxExecutionTimeMs: Long = 10 * 60 * 1000L
+)
+
+class BudgetTrackingCircuitBreaker(
+    private val providerOpenFor: Set<String> = emptySet(),
+    private val budget: TaskSafetyBudget = TaskSafetyBudget()
+) {
+    private var currentCostUsd = 0.0
+    private var toolCallsCount = 0
+    private val startTimeMs = kotlin.time.TimeSource.Monotonic.markNow().elapsedNow().inWholeMilliseconds
+
+    fun isOpen(providerId: String): Boolean = providerId in providerOpenFor
+
+    fun trackUsage(cost: Double) {
+        currentCostUsd += cost
+        if (currentCostUsd >= budget.maxCostUsd) throw CircuitBreakerException("Budget Limit Exceeded ($${currentCostUsd})")
+    }
+
+    fun incrementToolCall() {
+        toolCallsCount++
+        if (toolCallsCount >= budget.maxToolCallsCount) throw CircuitBreakerException("Tool Cap Reached ($toolCallsCount calls)")
+    }
+
+    fun checkTimeBudget() {
+        val elapsed = kotlin.time.TimeSource.Monotonic.markNow().elapsedNow().inWholeMilliseconds
+        if (elapsed >= budget.maxExecutionTimeMs) throw CircuitBreakerException("Time Budget Exceeded (${elapsed}ms)")
+    }
+
+    fun snapshot() = BudgetSnapshot(currentCostUsd, toolCallsCount, budget)
+}
+
+data class BudgetSnapshot(val costUsd: Double, val toolCalls: Int, val budget: TaskSafetyBudget)
+
+class CircuitBreakerException(message: String) : Exception(message)

--- a/agent-core/src/commonMain/kotlin/com/agent/code/mcp/MissionControlMcpServer.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/mcp/MissionControlMcpServer.kt
@@ -1,0 +1,62 @@
+package com.agent.code.mcp
+
+import com.agent.code.core.tools.RiskLevel
+import com.agent.code.core.tools.ToolResult
+import com.agent.code.workspace.FileSystemProvider
+import com.agent.code.workspace.ProcessRunner
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class MissionControlMcpServer(
+    private val mcpHost: McpHost,
+    private val fileSystem: FileSystemProvider,
+    private val processRunner: ProcessRunner
+) {
+    private val uiTools: Map<String, AgentTool> = mapOf(
+        InspectUiTool().let { it.name to it },
+        InteractUiTool().let { it.name to it }
+    )
+
+    private val allTools: Map<String, AgentTool> = mcpHost.listTools().associateWith { name ->
+        object : AgentTool {
+            override val name = name
+            override val description = "Delegated to McpHost"
+            override val riskLevel = RiskLevel.READ_ONLY
+            override suspend fun execute(argumentsJson: String, fileSystem: FileSystemProvider, processRunner: ProcessRunner): ToolResult =
+                mcpHost.dispatch(com.agent.code.core.fsm.ToolCall("mcp-$name", name, argumentsJson))
+        }
+    } + uiTools
+
+    suspend fun dispatch(toolCall: com.agent.code.core.fsm.ToolCall): ToolResult {
+        val tool = allTools[toolCall.toolName]
+            ?: return ToolResult(toolCall.id, false, "unknown tool: ${toolCall.toolName}", 0L)
+        return tool.execute(toolCall.argumentsJson, fileSystem, processRunner)
+    }
+
+    fun listTools(): List<McpToolDefinition> = allTools.values.map {
+        McpToolDefinition(it.name, it.description)
+    }
+}
+
+data class McpToolDefinition(val name: String, val description: String)
+
+private class InspectUiTool : AgentTool {
+    override val name = "inspect_ui_state"
+    override val description = "Dumps Android/Windows semantic layout tree"
+    override val riskLevel = RiskLevel.READ_ONLY
+
+    override suspend fun execute(argumentsJson: String, fileSystem: FileSystemProvider, processRunner: ProcessRunner): ToolResult {
+        return ToolResult("inspect_ui", true, "UI inspection not yet wired (requires AccessibilityEngine)", 0L)
+    }
+}
+
+private class InteractUiTool : AgentTool {
+    override val name = "interact_ui_element"
+    override val description = "Performs native click, text input, or swipe gestures"
+    override val riskLevel = RiskLevel.WRITE
+
+    override suspend fun execute(argumentsJson: String, fileSystem: FileSystemProvider, processRunner: ProcessRunner): ToolResult {
+        return ToolResult("interact_ui", true, "UI interaction not yet wired (requires AccessibilityEngine)", 0L)
+    }
+}

--- a/androidApp/src/main/kotlin/com/agent/code/service/ResilientAgentForegroundService.kt
+++ b/androidApp/src/main/kotlin/com/agent/code/service/ResilientAgentForegroundService.kt
@@ -14,6 +14,8 @@ import android.os.Build
 import android.os.IBinder
 import android.os.PowerManager
 import android.os.SystemClock
+import com.agent.code.core.elevation.PrivilegedElevationManager
+
 
 /**
  * Resilient foreground service that keeps the autonomous agent runtime alive
@@ -25,12 +27,14 @@ class ResilientAgentForegroundService : Service() {
 
     private var wakeLock: PowerManager.WakeLock? = null
     private var wifiLock: WifiManager.WifiLock? = null
+    private lateinit var elevationManager: PrivilegedElevationManager
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
+        elevationManager = PrivilegedElevationManager(this)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -41,6 +45,7 @@ class ResilientAgentForegroundService : Service() {
             startForeground(NOTIFICATION_ID, notification)
         }
 
+        elevationManager.applyZeroRootOptimizations()
         acquireLocks()
         scheduleWatchdog()
 

--- a/workspace-engine/src/androidMain/kotlin/com/agent/code/core/elevation/PrivilegedElevationManager.kt
+++ b/workspace-engine/src/androidMain/kotlin/com/agent/code/core/elevation/PrivilegedElevationManager.kt
@@ -1,0 +1,69 @@
+package com.agent.code.core.elevation
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+import android.content.pm.PackageManager
+import java.lang.reflect.Method
+import rikka.shizuku.Shizuku
+
+enum class ElevationStatus { StandardUserSpace, PrivilegedAdbUncapped }
+
+class PrivilegedElevationManager(private val context: Context) {
+
+    fun applyZeroRootOptimizations(): Result<ElevationStatus> {
+        if (!isShizukuAvailable()) {
+            return Result.success(ElevationStatus.StandardUserSpace)
+        }
+        return try {
+            executeAdbCommand("device_config put activity_manager max_phantom_processes 2147483647")
+            executeAdbCommand("settings put global settings_enable_monitor_phantom_procs false")
+            Result.success(ElevationStatus.PrivilegedAdbUncapped)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    fun requestDirectBatteryOptimizationExemption() {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        if (!powerManager.isIgnoringBatteryOptimizations(context.packageName)) {
+            val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                data = Uri.parse("package:${context.packageName}")
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            context.startActivity(intent)
+        }
+    }
+
+    private fun isShizukuAvailable(): Boolean = try {
+        Shizuku.pingBinder() &&
+            Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
+    } catch (_: Throwable) {
+        false
+    }
+
+    private val newProcessMethod: Method? by lazy {
+        try {
+            Shizuku::class.java.getDeclaredMethod(
+                "newProcess",
+                Array<String>::class.java,
+                Array<String>::class.java,
+                String::class.java
+            ).apply { isAccessible = true }
+        } catch (_: Throwable) { null }
+    }
+
+    private fun executeAdbCommand(command: String) {
+        val m = newProcessMethod ?: throw UnsupportedOperationException("Shizuku.newProcess unavailable")
+        val process = m.invoke(null, arrayOf("sh", "-c", command), null, null) as? Process
+            ?: throw UnsupportedOperationException("Shizuku.newProcess returned null")
+        val rc = process.waitFor()
+        if (rc != 0) {
+            val err = process.errorStream.bufferedReader().readText()
+            throw RuntimeException("ADB command failed (exit $rc): $err")
+        }
+    }
+}

--- a/workspace-engine/src/commonMain/kotlin/com/agent/code/tools/FetchDocTool.kt
+++ b/workspace-engine/src/commonMain/kotlin/com/agent/code/tools/FetchDocTool.kt
@@ -1,0 +1,42 @@
+package com.agent.code.tools
+
+import com.agent.code.core.tools.RiskLevel
+import com.agent.code.core.tools.ToolResult
+import com.agent.code.mcp.AgentTool
+import com.agent.code.workspace.FileSystemProvider
+import com.agent.code.workspace.ProcessRunner
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.URL
+
+class FetchDocTool : AgentTool {
+    override val name = "fetch_documentation"
+    override val description =
+        "Fetches latest library docs or README markdown from GitHub/web to verify API signatures."
+    override val riskLevel = RiskLevel.READ_ONLY
+
+    override suspend fun execute(
+        argumentsJson: String,
+        fileSystem: FileSystemProvider,
+        processRunner: ProcessRunner
+    ): ToolResult {
+        val url = try {
+            val obj = Json.parseToJsonElement(argumentsJson).jsonObject
+            obj["url"]?.jsonPrimitive?.content
+        } catch (_: Exception) { null }
+            ?: return ToolResult("fetch_doc", false, "Missing required argument: url", 0L)
+
+        return try {
+            val connection = URL(url).openConnection()
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 15_000
+            connection.setRequestProperty("User-Agent", "AgentCode/1.0")
+            val body = connection.getInputStream().bufferedReader().readText()
+            val truncated = if (body.length > 50_000) body.take(50_000) + "\n... (truncated)" else body
+            ToolResult("fetch_doc", true, truncated, body.length.toLong())
+        } catch (e: Exception) {
+            ToolResult("fetch_doc", false, "Fetch failed: ${e.message}", 0L)
+        }
+    }
+}


### PR DESCRIPTION
## M5.2 Platform Services
- PrivilegedElevationManager: Shizuku zero-root optimizations (phantom process bypass, battery exemption)
- Wired into ResilientAgentForegroundService

## M5.3 Tool & Protocol Layer
- BudgetTrackingCircuitBreaker: cost/tool-count/time tracking with TaskSafetyBudget
- FetchDocTool: web doc fetching (50KB truncation)
- MissionControlMcpServer: wraps McpHost + UI tool stubs

## CodeRabbit Fixes
- readTemperatures: >=10000→millidegrees, >=100→centidegrees, >=20→degrees
- AgentOrchestrator: ExecutingTool with empty toolCalls returns FatalError