### PR TITLE
fix: ai-apply-fix workflow_dispatch input types (number → string)

### DIFF
--- a/.github/workflows/ai-apply-fix.yml
+++ b/.github/workflows/ai-apply-fix.yml
@@ -8,11 +8,11 @@ on:
       pr_number:
         description: 'PR number to apply fixes to'
         required: true
-        type: number
+        type: string
       review_id:
         description: 'Review comment ID to parse fixes from'
         required: true
-        type: number
+        type: string
 
 concurrency:
   group: ai-fix-${{ github.event.issue.number || inputs.pr_number }}


### PR DESCRIPTION
Fix workflow_dispatch input types: number → string. type: number is invalid and caused YAML parse failure.
