### PR TITLE
fix: force re-parse of workflow triggers

### DIFF
--- a/.github/workflows/apply-fix.yml
+++ b/.github/workflows/apply-fix.yml
@@ -1,3 +1,4 @@
+# 2026-08-28: force re-parse to restore issue_comment trigger registration
 name: AI Fix
 
 on:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,3 +1,4 @@
+# 2026-08-28: force re-parse to restore issue_comment trigger registration
 name: AI AutoFix
 
 on:


### PR DESCRIPTION
Add comment lines to force GitHub Actions to re-parse workflow YAML. Both apply-fix.yml and autofix.yml have stale trigger registrations that prevent issue_comment and workflow_dispatch from firing. Same fix as qwen-code#9479.
