### PR TITLE
fix: compare durations directly in CircuitBreaker (commonMain-safe)

### DIFF
--- a/agent-core/src/commonMain/kotlin/com/agent/code/core/tools/CircuitBreaker.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/core/tools/CircuitBreaker.kt
@@ -1,5 +1,8 @@
 package com.agent.code.core.tools
 
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
 class CircuitBreaker(private val openFor: Set<String> = emptySet()) {
     fun isOpen(providerId: String): Boolean = providerId in openFor
 }
@@ -31,8 +34,9 @@ class BudgetTrackingCircuitBreaker(
     }
 
     fun checkTimeBudget() {
-        val elapsed = startMark.elapsedNow().inWholeMilliseconds
-        if (elapsed >= budget.maxExecutionTimeMs) throw CircuitBreakerException("Time Budget Exceeded (${elapsed}ms)")
+        val elapsed = startMark.elapsedNow()
+        if (elapsed >= budget.maxExecutionTimeMs.toDuration(DurationUnit.MILLISECONDS))
+            throw CircuitBreakerException("Time Budget Exceeded (${elapsed.inWholeMilliseconds}ms)")
     }
 
     fun snapshot() = BudgetSnapshot(currentCostUsd, toolCallsCount, budget)


### PR DESCRIPTION
Round 2 review fix for CircuitBreaker.kt.

- Compare elapsed Duration against maxExecutionTimeMs converted via common-compatible `kotlin.time.DurationUnit.MILLISECONDS` instead of JVM-only `TimeUnit` (which breaks commonMain compilation on JS/Native).
- Avoids Long truncation / unit coupling in the budget comparison.
- No dangling `startTimeMs` references (verified via grep).