### PR TITLE
Fixer hardening: symlink guard + agent-mode fixer (#65)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -329,6 +329,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
+      workflows: write
     concurrency:
       group: fix-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -532,14 +533,20 @@ jobs:
           set -euo pipefail
           if [ -n "${REVIEW_ID:-}" ] && git log --oneline --grep="Review #$REVIEW_ID" --fixed-strings HEAD | grep -q .; then
             echo "Already applied from review #$REVIEW_ID, skipping"
+            echo "pushed=none" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name "ai-review[bot]"; git config user.email "ai-review[bot]@users.noreply.github.com"
-            git add -A -- ':!.opencode' ':!.github/workflows'
+          git add -A -- ':!.opencode'
           # Drop any symlinks the agent staged (path-traversal guard, issue #65)
           git diff --cached --name-only | while IFS= read -r f; do [ -L "$f" ] && git restore --staged --quiet "$f" && echo "Skipped symlink: $f"; done
           if git diff --cached --quiet; then
             echo "Nothing staged to commit"
+            ALLMOD=$({ git diff --name-only; git ls-files --others --exclude-standard; } | grep -v '^\.opencode/')
+            if printf '%s\n' "$ALLMOD" | grep -q '^\.github/workflows/'; then
+              echo "reason=workflows-excluded" >> "$GITHUB_OUTPUT"
+            fi
+            echo "pushed=none" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           EXTRA=""; [ -n "${REVIEW_ID:-}" ] && EXTRA=$'\n\n'"Review #$REVIEW_ID"
@@ -555,17 +562,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           NUM: ${{ github.event.number }}
-          APPLIED: ${{ steps.apply.outputs.applied }}
-          FAILED: ${{ steps.apply.outputs.failed }}
           PUSHED: ${{ steps.commit.outputs.pushed }}
+          REASON: ${{ steps.commit.outputs.reason }}
         run: |
-          AP="${APPLIED:-0}"; FL="${FAILED:-0}"
-          B="## AI Fix Results\n\n| Applied | Failed |\n|---------|--------|\n| $AP | $FL |"
-          if [ "${AP:-0}" -gt 0 ] && [ "${PUSHED:-}" = "true" ]; then
+          PUSHED="${PUSHED:-}"
+          B="## AI Fix Results"
+          if [ "$PUSHED" = "true" ]; then
+            FILES=$(git show --pretty=format: --name-only HEAD | sed '/^$/d')
             HASH=$(git rev-parse --short HEAD)
-            B="$B\n\nCommit: \`$HASH\`"
-          elif [ "${PUSHED:-}" = "false" ]; then
-            B="$B\n\nPush failed -- commit exists locally only."
+            B="$B\n\nCommitted \`$HASH\` with fixes in:\n"
+            while IFS= read -r f; do [ -n "$f" ] && B="$B\n- \`$f\`"; done <<< "$FILES"
+          elif [ "$PUSHED" = "none" ]; then
+            if [ "${REASON:-}" = "workflows-excluded" ]; then
+              B="$B\n\nNo commit created. The agent's edits touched only \`.github/workflows\`, which is excluded from automated fixes (workflow changes need manual review). Apply manually or enable workflow editing."
+            else
+              B="$B\n\nNo commit created -- the agent made no committable changes."
+            fi
+          else
+            B="$B\n\nPush failed -- commit exists in the runner only."
           fi
           printf '%b' "$B" > /tmp/comment-body.md
           gh pr comment "$NUM" --body-file /tmp/comment-body.md
@@ -593,6 +607,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
     concurrency:
       group: fix-${{ github.event.pull_request.number }}
       cancel-in-progress: false

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,8 +18,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   review:
@@ -325,11 +326,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'fix-requested')
-    permissions:
-      contents: write
-      pull-requests: write
-      actions: write
-      workflows: write
     concurrency:
       group: fix-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -604,10 +600,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'autofix-requested')
-    permissions:
-      contents: write
-      pull-requests: write
-      workflows: write
     concurrency:
       group: fix-${{ github.event.pull_request.number }}
       cancel-in-progress: false

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -537,6 +537,8 @@ jobs:
           fi
           git config user.name "ai-review[bot]"; git config user.email "ai-review[bot]@users.noreply.github.com"
           git add -A -- ':!.opencode'
+          # Drop any symlinks the agent staged (path-traversal guard, issue #65)
+          git diff --cached --name-only | while IFS= read -r f; do [ -L "$f" ] && git restore --staged --quiet "$f" && echo "Skipped symlink: $f"; done
           if git diff --cached --quiet; then
             echo "Nothing staged to commit"
             exit 0

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,7 +20,6 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   review:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -532,7 +532,7 @@ jobs:
             exit 0
           fi
           git config user.name "ai-review[bot]"; git config user.email "ai-review[bot]@users.noreply.github.com"
-          git add -A -- ':!.opencode'
+          git add -A -- ':!.opencode' ':!.github/workflows'
           # Drop any symlinks the agent staged (path-traversal guard, issue #65)
           git diff --cached --name-only | while IFS= read -r f; do [ -L "$f" ] && git restore --staged --quiet "$f" && echo "Skipped symlink: $f"; done
           if git diff --cached --quiet; then

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -328,7 +328,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      workflows: write
       actions: write
     concurrency:
       group: fix-${{ github.event.pull_request.number }}
@@ -536,7 +535,7 @@ jobs:
             exit 0
           fi
           git config user.name "ai-review[bot]"; git config user.email "ai-review[bot]@users.noreply.github.com"
-          git add -A -- ':!.opencode'
+            git add -A -- ':!.opencode' ':!.github/workflows'
           # Drop any symlinks the agent staged (path-traversal guard, issue #65)
           git diff --cached --name-only | while IFS= read -r f; do [ -L "$f" ] && git restore --staged --quiet "$f" && echo "Skipped symlink: $f"; done
           if git diff --cached --quiet; then
@@ -594,7 +593,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      workflows: write
     concurrency:
       group: fix-${{ github.event.pull_request.number }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
- Stacked on the fixer rework (agent mode + git-diff commit + `workflows: write`): adds a symlink guard so the fixer never stages a symlink (path-traversal hardening, #65).
- Purpose: exercise the full pipeline — review (cached opencode) → fixer (agent edits files) → commit/push — on a fresh PR.

## Test
Review job should hit the opencode/plugin cache (populated by earlier runs). Add `fix-requested` and approve the workflow run in the Actions tab (the `workflows: write` permission added to the fixer requires maintainer approval for PR-triggered runs), then watch the fixer apply Major fixes.

🤖 Generated with [opencode](https://opencode.ai)