### PR TITLE
fix(pr-review): pull_request_target for label-triggered fix job

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -549,11 +549,11 @@ jobs:
           EXTRA=""; [ -n "${REVIEW_ID:-}" ] && EXTRA=$'\n\n'"Review #$REVIEW_ID"
           git commit -m "fix: apply AI review suggestions${EXTRA}"
           set +e
-          PUSH_OUT=$(git push "origin" "HEAD:refs/heads/$HEAD_REF" 2>&1)
+          git push "origin" "$SAFE" 2> /tmp/push-err.txt
           PRC=$?
           set -e
           if [ "$PRC" -ne 0 ]; then
-            echo "Push failed (exit $PRC): $PUSH_OUT"
+            echo "Push failed:"; cat /tmp/push-err.txt
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -809,11 +809,11 @@ jobs:
           MSG="fix: apply review findings (round $COUNT) - Hash: $HASH"
           git commit -m "$MSG" || { echo "Nothing to commit"; LAST_DONE="true"; break; }
           set +e
-          PUSH_OUT=$(git push "origin" "$SAFE" 2>&1)
+          git push "origin" "$SAFE" 2> /tmp/push-err.txt
           PRC=$?
           set -e
           if [ "$PRC" -ne 0 ]; then
-            echo "Push failed (exit $PRC): $PUSH_OUT"
+            echo "Push failed:"; cat /tmp/push-err.txt
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,11 +2,13 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled]
+    types: [opened, synchronize]
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - '.github/CODEOWNERS'
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -324,7 +326,7 @@ jobs:
   fix:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'fix-requested')
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && contains(github.event.pull_request.labels.*.name, 'fix-requested')
     concurrency:
       group: fix-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -547,11 +549,11 @@ jobs:
           EXTRA=""; [ -n "${REVIEW_ID:-}" ] && EXTRA=$'\n\n'"Review #$REVIEW_ID"
           git commit -m "fix: apply AI review suggestions${EXTRA}"
           set +e
-          git push "origin" "$SAFE" 2> /tmp/push-err.txt
+          PUSH_OUT=$(git push "origin" "HEAD:refs/heads/$HEAD_REF" 2>&1)
           PRC=$?
           set -e
           if [ "$PRC" -ne 0 ]; then
-            echo "Push failed:"; cat /tmp/push-err.txt
+            echo "Push failed (exit $PRC): $PUSH_OUT"
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -603,7 +605,7 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'autofix-requested')
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && contains(github.event.pull_request.labels.*.name, 'autofix-requested')
     concurrency:
       group: fix-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -807,11 +809,11 @@ jobs:
           MSG="fix: apply review findings (round $COUNT) - Hash: $HASH"
           git commit -m "$MSG" || { echo "Nothing to commit"; LAST_DONE="true"; break; }
           set +e
-          git push "origin" "$SAFE" 2> /tmp/push-err.txt
+          PUSH_OUT=$(git push "origin" "$SAFE" 2>&1)
           PRC=$?
           set -e
           if [ "$PRC" -ne 0 ]; then
-            echo "Push failed:"; cat /tmp/push-err.txt
+            echo "Push failed (exit $PRC): $PUSH_OUT"
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi


### PR DESCRIPTION
GITHUB_TOKEN from pull_request events cannot push to PR branches. Switching label-triggered jobs to pull_request_target which can.