### PR TITLE
fix: grep exits 1 on no match, kills fix step under set -e

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -489,7 +489,7 @@ jobs:
           tail -30 /tmp/opencode-fix-result.txt >&2
 
           COUNT=0
-          MODIFIED=$({ git diff --name-only; git ls-files --others --exclude-standard; } | grep -v '^\.opencode/' | sort -u)
+          MODIFIED=$({ git diff --name-only; git ls-files --others --exclude-standard; } | { grep -v '^\.opencode/' || true; } | sort -u)
           if [ -n "$MODIFIED" ]; then
             COUNT=$(printf '%s\n' "$MODIFIED" | wc -l)
             DELIM="MODOUT_${GITHUB_RUN_ID}"
@@ -545,7 +545,7 @@ jobs:
           git diff --cached --name-only | while IFS= read -r f; do [ -L "$f" ] && git restore --staged --quiet "$f" && echo "Skipped symlink: $f"; done
           if git diff --cached --quiet; then
             echo "Nothing staged to commit"
-            ALLMOD=$({ git diff --name-only; git ls-files --others --exclude-standard; } | grep -v '^\.opencode/')
+            ALLMOD=$({ git diff --name-only; git ls-files --others --exclude-standard; } | { grep -v '^\.opencode/' || true; })
             if printf '%s\n' "$ALLMOD" | grep -q '^\.github/workflows/'; then
               echo "reason=workflows-excluded" >> "$GITHUB_OUTPUT"
             fi


### PR DESCRIPTION
Two `grep -v` calls in the fix step fail with exit code 1 when input is empty (no file changes). Under `set -e`, this kills the entire script before the error handler runs.

Fix: wrap each grep in `{ grep ... || true; }` so exit 1 is absorbed.