### PR TITLE
fix: add install retry and graceful comment fallback

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -46,7 +46,10 @@ jobs:
       - name: Install opencode
         if: steps.cache-opencode.outputs.cache-hit != 'true'
         run: |
-          curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh
+          for i in 1 2 3; do
+            curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh && break
+            echo "Attempt $i failed, retrying in 10s..." >&2; sleep 10
+          done
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
           opencode --version || { echo "::error::opencode install verification failed"; exit 1; }
@@ -319,10 +322,15 @@ jobs:
 
       - name: Comment on PR
         if: always() && (github.event_name == 'pull_request' || inputs.pr_number)
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88  # v3.0.5
-        with:
-          path: /tmp/review.md
-          header: ai-review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUM: ${{ github.event.number }}
+        run: |
+          if [ -f /tmp/review.md ] && [ -s /tmp/review.md ]; then
+            gh pr comment "$NUM" --body-file /tmp/review.md
+          else
+            gh pr comment "$NUM" --body "⚠️ AI review failed — could not generate review (install or network error). The workflow will succeed on retry."
+          fi
 
   fix:
     runs-on: ubuntu-latest
@@ -373,7 +381,10 @@ jobs:
       - name: Install opencode
         if: steps.cache-opencode.outputs.cache-hit != 'true'
         run: |
-          curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh
+          for i in 1 2 3; do
+            curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh && break
+            echo "Attempt $i failed, retrying in 10s..." >&2; sleep 10
+          done
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
           opencode --version || { echo "::error::opencode install verification failed"; exit 1; }
@@ -656,7 +667,10 @@ jobs:
       - name: Install opencode
         if: steps.cache-opencode.outputs.cache-hit != 'true'
         run: |
-          curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh
+          for i in 1 2 3; do
+            curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh && break
+            echo "Attempt $i failed, retrying in 10s..." >&2; sleep 10
+          done
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
           opencode --version || { echo "::error::opencode install verification failed"; exit 1; }

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -52,7 +52,7 @@ jobs:
           done
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
-          opencode --version || { echo "::error::opencode install verification failed"; exit 1; }
+          "$HOME/.opencode/bin/opencode" --version || { echo "::error::opencode install verification failed"; exit 1; }
 
       - name: Add opencode to PATH
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
@@ -387,7 +387,7 @@ jobs:
           done
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
-          opencode --version || { echo "::error::opencode install verification failed"; exit 1; }
+          "$HOME/.opencode/bin/opencode" --version || { echo "::error::opencode install verification failed"; exit 1; }
 
       - name: Add opencode to PATH
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
@@ -673,7 +673,7 @@ jobs:
           done
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
-          opencode --version || { echo "::error::opencode install verification failed"; exit 1; }
+          "$HOME/.opencode/bin/opencode" --version || { echo "::error::opencode install verification failed"; exit 1; }
 
       - name: Add opencode to PATH
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -49,6 +49,7 @@ jobs:
           curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
+          opencode --version || { echo "::error::opencode install verification failed"; exit 1; }
 
       - name: Add opencode to PATH
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
@@ -131,7 +132,7 @@ jobs:
             local tmp_files=()
             local result_file="/tmp/round-review-${round}.md"
 
-            cleanup_local() { rm -f "${tmp_files[@]}"; }
+            cleanup_local() { rm -f "${tmp_files[@]}" "$result_file"; }
             trap cleanup_local RETURN INT TERM
 
             > "$result_file"
@@ -375,6 +376,7 @@ jobs:
           curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
+          opencode --version || { echo "::error::opencode install verification failed"; exit 1; }
 
       - name: Add opencode to PATH
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
@@ -657,6 +659,7 @@ jobs:
           curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh
           bash /tmp/install-opencode.sh
           rm -f /tmp/install-opencode.sh
+          opencode --version || { echo "::error::opencode install verification failed"; exit 1; }
 
       - name: Add opencode to PATH
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
@@ -793,7 +796,9 @@ jobs:
                   if not os.path.exists(fp): failed += 1; continue
                   try:
                       with open(fp) as f: c = f.read()
-                      if fix['before'] not in c: failed += 1; continue
+                      count = c.count(fix['before'])
+                      if count == 0: failed += 1; continue
+                      if count > 1: print(f'  Ambiguous: {fix["before"][:40]}... found {count} times in {fp}, skipping'); failed += 1; continue
                       fd, tmp = tempfile.mkstemp(dir=os.path.dirname(fp) or '.')
                       with os.fdopen(fd,'w') as tmpf: tmpf.write(c.replace(fix['before'], fix['after'], 1))
                       os.replace(tmp, fp); applied += 1


### PR DESCRIPTION
## Changes
- **curl retry**: 3 attempts with 10s delay on all 3 jobs (review, fix, autofix) — opencode.ai connection resets were killing builds
- **Graceful comment fallback**: Comment step now checks if review.md exists before posting. If missing (install failure), posts a warning instead of crashing with 'Either message or path input is required'