### PR TITLE
fix: restore sticky comment action, remove fallback

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -40,8 +40,8 @@ jobs:
         id: cache-opencode
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ${{ env.HOME }}/.opencode
-          key: opencode-${{ runner.os }}-v1
+          path: /home/runner/.opencode
+          key: opencode-${{ runner.os }}-v2
 
       - name: Install opencode
         if: steps.cache-opencode.outputs.cache-hit != 'true'
@@ -370,8 +370,8 @@ jobs:
         id: cache-opencode
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ${{ env.HOME }}/.opencode
-          key: opencode-${{ runner.os }}-v1
+          path: /home/runner/.opencode
+          key: opencode-${{ runner.os }}-v2
 
       - name: Install opencode
         if: steps.cache-opencode.outputs.cache-hit != 'true'
@@ -656,8 +656,8 @@ jobs:
         id: cache-opencode
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ${{ env.HOME }}/.opencode
-          key: opencode-${{ runner.os }}-v1
+          path: /home/runner/.opencode
+          key: opencode-${{ runner.os }}-v2
 
       - name: Install opencode
         if: steps.cache-opencode.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -322,15 +322,10 @@ jobs:
 
       - name: Comment on PR
         if: always() && (github.event_name == 'pull_request' || inputs.pr_number)
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NUM: ${{ github.event.number }}
-        run: |
-          if [ -f /tmp/review.md ] && [ -s /tmp/review.md ]; then
-            gh pr comment "$NUM" --body-file /tmp/review.md
-          else
-            gh pr comment "$NUM" --body "⚠️ AI review failed — could not generate review (install or network error). The workflow will succeed on retry."
-          fi
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88  # v3.0.5
+        with:
+          path: /tmp/review.md
+          header: ai-review
 
   fix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The graceful fallback masked install failures instead of fixing them. The real fixes are:
1. `opencode --version` now uses absolute path (PATH not set until next step)
2. curl retry (3 attempts, 10s delay) for transient network issues

Both already on main. This PR removes the graceful fallback and restores the sticky comment action so failures are visible.