### PR TITLE
fix: RETURN trap was silently deleting review result file

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -136,7 +136,9 @@ jobs:
             local result_file="/tmp/round-review-${round}.md"
 
             cleanup_local() { rm -f "${tmp_files[@]}"; }
-            trap cleanup_local RETURN INT TERM
+            cleanup_all() { rm -f "${tmp_files[@]}" "$result_file"; }
+            trap cleanup_local RETURN
+            trap cleanup_all INT TERM
 
             > "$result_file"
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -135,7 +135,7 @@ jobs:
             local tmp_files=()
             local result_file="/tmp/round-review-${round}.md"
 
-            cleanup_local() { rm -f "${tmp_files[@]}" "$result_file"; }
+            cleanup_local() { rm -f "${tmp_files[@]}"; }
             trap cleanup_local RETURN INT TERM
 
             > "$result_file"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -128,6 +128,7 @@ jobs:
           RETRY_DELAY=15
           ALL_FINDINGS=""
           CONVERGENCE_REASON=""
+          trap 'rm -f /tmp/round-review-*.md' EXIT
 
           review_round() {
             local prompt_file="$1"


### PR DESCRIPTION
The RETURN trap in review_round() deleted $result_file on success, so the cat on line 246 always failed silently. Removed $result_file from trap cleanup — it's already cleaned up by rm on line 247.