### PR TITLE
feat(m6): Phase 4 — UI hook-up connecting real agent system

### DIFF
--- a/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
@@ -4,11 +4,14 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import com.agent.code.core.path.VirtualPath
 import com.agent.code.core.power.AndroidPowerGovernor
 import com.agent.code.service.ResilientAgentForegroundService
-import com.agent.code.ui.ProbeDashboard
+import com.agent.code.ui.AgentViewModel
+import com.agent.code.workspace.RealFileSystem
+import com.agent.code.workspace.GitProcessRunner
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -16,22 +19,23 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val governor = AndroidPowerGovernor(applicationContext)
-
         ResilientAgentForegroundService.start(this)
 
+        val workspaceRoot = VirtualPath.of(filesDir.absolutePath)
+
         setContent {
+            val scope = rememberCoroutineScope()
+            val viewModel = remember {
+                AgentViewModel.create(
+                    scope = scope,
+                    fileSystem = RealFileSystem(workspaceRoot),
+                    processRunner = GitProcessRunner(),
+                    workspaceRoot = workspaceRoot
+                )
+            }
             App(
-                probeDashboard = {
-                    ProbeDashboard(baseDir = filesDir.absolutePath, governor = governor)
-                },
-                governor = governor,
+                agentViewModel = viewModel,
             )
         }
     }
-}
-
-@Preview
-@Composable
-fun AppAndroidPreview() {
-    App()
 }

--- a/app-ui/build.gradle.kts
+++ b/app-ui/build.gradle.kts
@@ -40,6 +40,8 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.datetime)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.okhttp)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/app-ui/src/commonMain/kotlin/com/agent/code/App.kt
+++ b/app-ui/src/commonMain/kotlin/com/agent/code/App.kt
@@ -28,6 +28,8 @@ import com.agent.code.core.journal.TelemetryEngine
 import com.agent.code.core.power.PowerGovernor
 import com.agent.code.core.power.StubPowerGovernor
 import com.agent.code.provider.HierarchicalModelRouter
+import com.agent.code.ui.AgentPanel
+import com.agent.code.ui.AgentViewModel
 import com.agent.code.ui.DashboardScreen
 import com.agent.code.ui.demoModelRouter
 import kotlinx.coroutines.launch
@@ -37,23 +39,14 @@ import kotlinx.coroutines.launch
 fun App(
     probeDashboard: @Composable (() -> Unit)? = null,
     governor: PowerGovernor = StubPowerGovernor(),
+    agentViewModel: AgentViewModel? = null,
 ) {
     MaterialTheme {
         var showSpine by remember { mutableStateOf(false) }
         var showDash by remember { mutableStateOf(false) }
+        var showAgent by remember { mutableStateOf(agentViewModel != null) }
         val telemetry = remember { TelemetryEngine() }
         val router: HierarchicalModelRouter = remember { demoModelRouter() }
-
-        // Emit M3 demo telemetry events for DashboardScreen to observe
-        LaunchedEffect(telemetry) {
-            var seq = 0L
-            while (true) {
-                kotlinx.coroutines.delay(2000)
-                val ts = System.currentTimeMillis()
-                telemetry.emit(LogEntry.AgentThought(ts, "Demo thought ${seq++}"))
-                telemetry.emit(LogEntry.ToolCallStarted(ts + 10, "demo_tool", """{"arg":"value"}"""))
-            }
-        }
 
         Column(
             modifier = Modifier
@@ -63,6 +56,14 @@ fun App(
                 .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            if (agentViewModel != null) {
+                Button(onClick = { showAgent = !showAgent }) {
+                    Text("M6 Agent")
+                }
+                AnimatedVisibility(showAgent) {
+                    AgentPanel(viewModel = agentViewModel)
+                }
+            }
             Button(onClick = { showSpine = !showSpine }) {
                 Text("M0.5 Spine Demo")
             }

--- a/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentPanel.kt
+++ b/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentPanel.kt
@@ -1,0 +1,157 @@
+package com.agent.code.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.agent.code.opencode.OpenCodeState
+
+@Composable
+fun AgentPanel(
+    viewModel: AgentViewModel,
+    modifier: Modifier = Modifier
+) {
+    val state by viewModel.state.collectAsState()
+    var inputText by remember { mutableStateOf("") }
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(state.events.size) {
+        if (state.events.isNotEmpty()) {
+            listState.animateScrollToItem(state.events.lastIndex)
+        }
+    }
+
+    Column(modifier = modifier.fillMaxWidth().padding(8.dp)) {
+        ProcessStatusHeader(
+            processState = state.processState,
+            isRunning = state.isRunning,
+            onStart = { viewModel.startOpenCode() },
+            onStop = { viewModel.stopOpenCode() }
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(
+                value = inputText,
+                onValueChange = { inputText = it },
+                modifier = Modifier.weight(1f),
+                placeholder = { Text("Agent goal...") },
+                enabled = !state.isRunning && state.processState is OpenCodeState.Running,
+                singleLine = true
+            )
+            Spacer(Modifier.width(8.dp))
+            Button(
+                onClick = {
+                    viewModel.executeTask(inputText)
+                    inputText = ""
+                },
+                enabled = !state.isRunning && inputText.isNotBlank()
+                        && state.processState is OpenCodeState.Running
+            ) { Text("Run") }
+            if (state.isRunning) {
+                Spacer(Modifier.width(4.dp))
+                OutlinedButton(onClick = { viewModel.cancelTask() }) { Text("Stop") }
+            }
+        }
+
+        state.error?.let {
+            Spacer(Modifier.height(4.dp))
+            Text("Error: $it", color = MaterialTheme.colorScheme.error, fontSize = 12.sp)
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxWidth().weight(1f).background(
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                RoundedCornerShape(4.dp)
+            ).padding(4.dp)
+        ) {
+            items(state.events) { event ->
+                AgentEventRow(event)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProcessStatusHeader(
+    processState: OpenCodeState,
+    isRunning: Boolean,
+    onStart: () -> Unit,
+    onStop: () -> Unit
+) {
+    Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val (label, color) = when (processState) {
+            is OpenCodeState.NotInstalled -> "Not installed" to MaterialTheme.colorScheme.error
+            is OpenCodeState.Installing -> "Installing" to MaterialTheme.colorScheme.primary
+            is OpenCodeState.Starting -> "Starting..." to MaterialTheme.colorScheme.primary
+            is OpenCodeState.Running -> "Running on :${processState.port}" to MaterialTheme.colorScheme.tertiary
+            is OpenCodeState.Error -> "Error: ${processState.message}" to MaterialTheme.colorScheme.error
+            is OpenCodeState.Stopped -> "Stopped" to MaterialTheme.colorScheme.onSurfaceVariant
+        }
+        Text("OpenCode: $label", color = color, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+        Row {
+            if (processState is OpenCodeState.NotInstalled
+                || processState is OpenCodeState.Error
+                || processState is OpenCodeState.Stopped
+            ) {
+                TextButton(onClick = onStart) { Text("Start") }
+            }
+            if (processState is OpenCodeState.Running) {
+                TextButton(onClick = onStop) { Text("Stop") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AgentEventRow(event: UiEvent) {
+    val icon: String
+    val text: String
+    val color: androidx.compose.ui.graphics.Color
+    val font: FontFamily
+    when (event) {
+        is UiEvent.Thinking -> { icon = "\uD83D\uDCAD"; text = event.text; color = MaterialTheme.colorScheme.onSurface; font = FontFamily.Default }
+        is UiEvent.ToolStarted -> { icon = "\uD83D\uDD27"; text = "\u2192 ${event.name}(${event.args.take(80)})"; color = MaterialTheme.colorScheme.primary; font = FontFamily.Monospace }
+        is UiEvent.ToolFinished -> {
+            icon = if (event.success) "\u2705" else "\u274C"
+            text = "\u2190 ${event.name} ${if (event.success) "ok" else "FAIL"}"
+            color = MaterialTheme.colorScheme.onSurface
+            font = FontFamily.Monospace
+        }
+        is UiEvent.Iteration -> { icon = "\uD83D\uDD04"; text = "Iteration ${event.number} complete"; color = MaterialTheme.colorScheme.onSurface; font = FontFamily.Default }
+        is UiEvent.Complete -> { icon = "\u2705"; text = "Done: ${event.summary}"; color = MaterialTheme.colorScheme.tertiary; font = FontFamily.Default }
+        is UiEvent.Failed -> { icon = "\u274C"; text = "Failed: ${event.reason}"; color = MaterialTheme.colorScheme.error; font = FontFamily.Default }
+    }
+
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 1.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text("$icon ", fontSize = 11.sp)
+        Text(
+            text = text,
+            fontSize = 11.sp,
+            color = color,
+            fontFamily = font,
+            lineHeight = 14.sp
+        )
+    }
+}

--- a/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentViewModel.kt
+++ b/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentViewModel.kt
@@ -1,0 +1,155 @@
+package com.agent.code.ui
+
+import com.agent.code.core.journal.AgentEvent
+import com.agent.code.core.journal.AgentEventJournal
+import com.agent.code.core.journal.InMemoryWalStore
+import com.agent.code.core.journal.TelemetryEngine
+import com.agent.code.core.path.VirtualPath
+import com.agent.code.mcp.McpHost
+import com.agent.code.opencode.AgentBrain
+import com.agent.code.opencode.AgentConfig
+import com.agent.code.opencode.BrainEvent
+import com.agent.code.opencode.OpenCodeClient
+import com.agent.code.opencode.OpenCodeManager
+import com.agent.code.opencode.OpenCodeState
+import com.agent.code.workspace.FileSystemProvider
+import com.agent.code.workspace.ProcessRunner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class AgentUiState(
+    val processState: OpenCodeState = OpenCodeState.NotInstalled,
+    val isRunning: Boolean = false,
+    val currentGoal: String = "",
+    val events: List<UiEvent> = emptyList(),
+    val error: String? = null
+)
+
+sealed interface UiEvent {
+    data class Thinking(val text: String) : UiEvent
+    data class ToolStarted(val name: String, val args: String) : UiEvent
+    data class ToolFinished(val name: String, val success: Boolean) : UiEvent
+    data class Iteration(val number: Int) : UiEvent
+    data class Complete(val summary: String) : UiEvent
+    data class Failed(val reason: String) : UiEvent
+}
+
+class AgentViewModel(
+    private val scope: CoroutineScope,
+    private val openCodeManager: OpenCodeManager,
+    private val openCodeClient: OpenCodeClient,
+    private val brain: AgentBrain,
+    private val journal: AgentEventJournal,
+    private val telemetry: TelemetryEngine,
+    private val workspaceRoot: VirtualPath
+) {
+    private val _state = MutableStateFlow(AgentUiState())
+    val state: StateFlow<AgentUiState> = _state.asStateFlow()
+
+    private var brainJob: Job? = null
+    private var statePollJob: Job? = null
+
+    fun startOpenCode() {
+        if (statePollJob != null) return
+        statePollJob = scope.launch {
+            while (true) {
+                _state.value = _state.value.copy(processState = openCodeManager.currentState())
+                delay(500)
+            }
+        }
+        scope.launch {
+            try {
+                openCodeManager.ensureInstalled()
+                openCodeManager.start(projectDir = workspaceRoot)
+            } catch (e: Exception) {
+                _state.value = _state.value.copy(
+                    processState = OpenCodeState.Error(e.message ?: "start failed")
+                )
+            }
+        }
+    }
+
+    fun stopOpenCode() {
+        statePollJob?.cancel()
+        statePollJob = null
+        scope.launch {
+            openCodeManager.stop()
+            _state.value = _state.value.copy(processState = OpenCodeState.Stopped)
+        }
+    }
+
+    fun executeTask(goal: String) {
+        if (_state.value.isRunning) return
+        brainJob?.cancel()
+
+        _state.value = _state.value.copy(
+            isRunning = true,
+            currentGoal = goal,
+            events = emptyList(),
+            error = null
+        )
+
+        brainJob = scope.launch {
+            try {
+                val taskId = "T-${System.currentTimeMillis()}"
+                val events = mutableListOf<UiEvent>()
+
+                brain.executeTask(taskId, goal, workspaceRoot).collect { event ->
+                    val uiEvent = when (event) {
+                        is BrainEvent.Thinking -> UiEvent.Thinking(event.text)
+                        is BrainEvent.ToolCallStarted -> UiEvent.ToolStarted(event.toolName, event.args)
+                        is BrainEvent.ToolCallFinished -> UiEvent.ToolFinished(event.toolName, event.success)
+                        is BrainEvent.IterationComplete -> UiEvent.Iteration(event.iteration)
+                        is BrainEvent.TaskComplete -> UiEvent.Complete(event.summary)
+                        is BrainEvent.TaskFailed -> UiEvent.Failed(event.reason)
+                    }
+                    events.add(uiEvent)
+                    _state.value = _state.value.copy(events = events.toList())
+
+                    if (event is BrainEvent.TaskComplete || event is BrainEvent.TaskFailed) {
+                        _state.value = _state.value.copy(isRunning = false)
+                    }
+                }
+            } catch (e: Exception) {
+                _state.value = _state.value.copy(
+                    isRunning = false,
+                    error = "${e::class.simpleName}: ${e.message}"
+                )
+            }
+        }
+    }
+
+    fun cancelTask() {
+        brainJob?.cancel()
+        brainJob = null
+        _state.value = _state.value.copy(isRunning = false)
+    }
+
+    fun destroy() {
+        cancelTask()
+        statePollJob?.cancel()
+        scope.launch { openCodeManager.stop() }
+    }
+
+    companion object {
+        fun create(
+            scope: CoroutineScope,
+            fileSystem: FileSystemProvider,
+            processRunner: ProcessRunner,
+            workspaceRoot: VirtualPath
+        ): AgentViewModel {
+            val manager = OpenCodeManager(fileSystem, processRunner)
+            val client = OpenCodeClient(io.ktor.client.HttpClient(), manager)
+            val journal = AgentEventJournal(InMemoryWalStore())
+            val telemetry = TelemetryEngine(scope)
+            val mcp = McpHost(fileSystem, processRunner)
+            val brain = AgentBrain(client, mcp, journal, telemetry)
+            return AgentViewModel(scope, manager, client, brain, journal, telemetry, workspaceRoot)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Wire real OpenCodeManager, OpenCodeClient, AgentBrain to CMP UI.

## Changes
- **AgentViewModel**: state holder managing process lifecycle and task execution via  flow
- **AgentPanel**: streaming composable showing OpenCode process status, goal input, and real-time agent events (thinking, tool calls, iterations, completion)
- **App.kt**: optional  parameter renders AgentPanel when provided
- **MainActivity**: creates  + , constructs  via companion factory
- **app-ui**: added  and  dependencies

## Architecture
```
MainActivity
  └─ AgentViewModel.create(scope, RealFileSystem, GitProcessRunner, workspaceRoot)
       ├─ OpenCodeManager (process lifecycle)
       ├─ OpenCodeClient (HTTP to local OpenCode server)
       ├─ AgentBrain (agent execution loop)
       ├─ McpHost (tool dispatch)
       └─ AgentEventJournal + TelemetryEngine
```

The UI polls  every 500ms and collects  stream from .