### PR TITLE
feat(m6): Phase 5 — security hardening for agent tools

### DIFF
--- a/agent-core/src/commonMain/kotlin/com/agent/code/mcp/GitTool.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/mcp/GitTool.kt
@@ -3,6 +3,10 @@ package com.agent.code.mcp
 import com.agent.code.core.path.VirtualPath
 import com.agent.code.core.tools.RiskLevel
 import com.agent.code.core.tools.ToolResult
+import com.agent.code.security.AuditLog
+import com.agent.code.security.EmergencyStop
+import com.agent.code.security.GitDecision
+import com.agent.code.security.GitGuard
 import com.agent.code.workspace.FileSystemProvider
 import com.agent.code.workspace.ProcessConfiguration
 import com.agent.code.workspace.ProcessRunner
@@ -17,6 +21,8 @@ class GitTool : AgentTool {
     override val riskLevel = RiskLevel.WRITE
 
     override suspend fun execute(argumentsJson: String, fileSystem: FileSystemProvider, processRunner: ProcessRunner): ToolResult {
+        EmergencyStop.check()
+
         val obj = try {
             Json.parseToJsonElement(argumentsJson).jsonObject
         } catch (_: Exception) {
@@ -27,6 +33,12 @@ class GitTool : AgentTool {
         val args = obj["args"]?.jsonPrimitive?.contentOrNull ?: ""
         val workingDir = obj["working_dir"]?.jsonPrimitive?.contentOrNull
         val message = obj["message"]?.jsonPrimitive?.contentOrNull
+
+        val decision = GitGuard.isAllowed(subcommand, args)
+        if (decision is GitDecision.Blocked) {
+            AuditLog.log(name, argumentsJson, false, decision.reason, blocked = true, blockReason = decision.reason)
+            return ToolResult(name, false, "blocked: ${decision.reason}", 0L)
+        }
 
         val dir = if (workingDir != null) VirtualPath.of(workingDir) else VirtualPath.of(".")
         val cmd = buildList {
@@ -57,13 +69,17 @@ class GitTool : AgentTool {
                         if (output.stdout.isNotBlank()) appendLine(output.stdout)
                         if (output.stderr.isNotBlank()) appendLine("STDERR:\n${output.stderr}")
                     }.trim()
-                    ToolResult(name, output.exitCode == 0, combined.ifBlank { "exit ${output.exitCode}" }, elapsed)
+                    val success = output.exitCode == 0
+                    AuditLog.log(name, argumentsJson, success, combined)
+                    ToolResult(name, success, combined.ifBlank { "exit ${output.exitCode}" }, elapsed)
                 },
                 onFailure = { e ->
+                    AuditLog.log(name, argumentsJson, false, e.message ?: "failed")
                     ToolResult(name, false, "git failed: ${e.message}", System.currentTimeMillis() - start)
                 }
             )
         } catch (e: Exception) {
+            AuditLog.log(name, argumentsJson, false, e.message ?: "error")
             ToolResult(name, false, "error: ${e.message}", System.currentTimeMillis() - start)
         }
     }

--- a/agent-core/src/commonMain/kotlin/com/agent/code/mcp/TerminalTool.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/mcp/TerminalTool.kt
@@ -3,6 +3,9 @@ package com.agent.code.mcp
 import com.agent.code.core.path.VirtualPath
 import com.agent.code.core.tools.RiskLevel
 import com.agent.code.core.tools.ToolResult
+import com.agent.code.security.AuditLog
+import com.agent.code.security.CommandAllowlist
+import com.agent.code.security.EmergencyStop
 import com.agent.code.workspace.FileSystemProvider
 import com.agent.code.workspace.ProcessConfiguration
 import com.agent.code.workspace.ProcessRunner
@@ -17,6 +20,8 @@ class TerminalTool : AgentTool {
     override val riskLevel = RiskLevel.WRITE
 
     override suspend fun execute(argumentsJson: String, fileSystem: FileSystemProvider, processRunner: ProcessRunner): ToolResult {
+        EmergencyStop.check()
+
         val obj = try {
             Json.parseToJsonElement(argumentsJson).jsonObject
         } catch (_: Exception) {
@@ -26,6 +31,12 @@ class TerminalTool : AgentTool {
             ?: return ToolResult(name, false, "missing 'command'", 0L)
         val workingDir = obj["working_dir"]?.jsonPrimitive?.contentOrNull
         val timeout = obj["timeout_ms"]?.jsonPrimitive?.content?.toLongOrNull() ?: 30_000L
+
+        if (!CommandAllowlist.isAllowed(command)) {
+            val reason = CommandAllowlist.reason(command) ?: "command blocked"
+            AuditLog.log(name, argumentsJson, false, reason, blocked = true, blockReason = reason)
+            return ToolResult(name, false, "blocked: $reason", 0L)
+        }
 
         val dir = if (workingDir != null) VirtualPath.of(workingDir) else VirtualPath.of(".")
         val config = ProcessConfiguration(
@@ -45,13 +56,16 @@ class TerminalTool : AgentTool {
                         if (output.stderr.isNotBlank()) appendLine("STDERR:\n${output.stderr}")
                     }.trim()
                     val success = output.exitCode == 0
+                    AuditLog.log(name, argumentsJson, success, combined)
                     ToolResult(name, success, combined.ifBlank { "exit ${output.exitCode}" }, elapsed)
                 },
                 onFailure = { e ->
+                    AuditLog.log(name, argumentsJson, false, e.message ?: "failed")
                     ToolResult(name, false, "command failed: ${e.message}", System.currentTimeMillis() - start)
                 }
             )
         } catch (e: Exception) {
+            AuditLog.log(name, argumentsJson, false, e.message ?: "error")
             ToolResult(name, false, "error: ${e.message}", System.currentTimeMillis() - start)
         }
     }

--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
@@ -1,0 +1,58 @@
+package com.agent.code.security
+
+import kotlinx.datetime.Clock
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AuditEntry(
+    val timestampMs: Long,
+    val toolName: String,
+    val argumentsSummary: String,
+    val success: Boolean,
+    val outputSummary: String,
+    val blocked: Boolean = false,
+    val blockReason: String? = null
+)
+
+object AuditLog {
+    private val entries = mutableListOf<AuditEntry>()
+    private val maxEntries = 1000
+
+    fun record(entry: AuditEntry) {
+        synchronized(entries) {
+            entries.add(entry)
+            if (entries.size > maxEntries) {
+                entries.removeAt(0)
+            }
+        }
+    }
+
+    fun log(
+        toolName: String,
+        argumentsJson: String,
+        success: Boolean,
+        output: String,
+        blocked: Boolean = false,
+        blockReason: String? = null
+    ) {
+        record(AuditEntry(
+            timestampMs = Clock.System.now().toEpochMilliseconds(),
+            toolName = toolName,
+            argumentsSummary = argumentsJson.take(200),
+            success = success,
+            outputSummary = output.take(500),
+            blocked = blocked,
+            blockReason = blockReason
+        ))
+    }
+
+    fun recent(count: Int = 50): List<AuditEntry> {
+        synchronized(entries) {
+            return entries.takeLast(count)
+        }
+    }
+
+    fun clear() {
+        synchronized(entries) { entries.clear() }
+    }
+}

--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/CommandAllowlist.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/CommandAllowlist.kt
@@ -1,0 +1,61 @@
+package com.agent.code.security
+
+object CommandAllowlist {
+    private val blockedCommands = setOf(
+        "rm -rf /",
+        "rm -rf /*",
+        "mkfs",
+        "dd if=",
+        ":(){ :|:& };:",
+        "chmod -R 777 /",
+        "wget",
+        "curl",
+        "nc ",
+        "ncat",
+        "socat",
+        "shutdown",
+        "reboot",
+        "halt",
+        "poweroff",
+        "init 0",
+        "init 6",
+        "kill -9 1",
+        "killall",
+        "pkill",
+        "kill -1",
+        "kill -2",
+    )
+
+    private val blockedPatterns = listOf(
+        Regex("""rm\s+.*-rf\s+/\s"""),
+        Regex("""rm\s+-[a-z]*r[a-z]*f"""),
+        Regex(""">\s*/dev/sd"""),
+        Regex("""mkfs\."""),
+        Regex("""mount\s"""),
+        Regex("""umount\s"""),
+        Regex("""/etc/passwd"""),
+        Regex("""/etc/shadow"""),
+        Regex("""\.ssh/"""),
+        Regex("""authorized_keys"""),
+        Regex("""crontab"""),
+        Regex("""systemctl"""),
+        Regex("""service\s+\w+\s+stop"""),
+        Regex("""kill\s+-9\s+\d+"""),
+    )
+
+    fun isAllowed(command: String): Boolean {
+        val normalized = command.trim().lowercase()
+        if (blockedCommands.any { normalized.startsWith(it) }) return false
+        if (blockedPatterns.any { it.containsMatchIn(normalized) }) return false
+        return true
+    }
+
+    fun reason(command: String): String? {
+        val normalized = command.trim().lowercase()
+        val blocked = blockedCommands.firstOrNull { normalized.startsWith(it) }
+        if (blocked != null) return "blocked command: $blocked"
+        val pattern = blockedPatterns.firstOrNull { it.containsMatchIn(normalized) }
+        if (pattern != null) return "blocked pattern: $pattern"
+        return null
+    }
+}

--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/EmergencyStop.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/EmergencyStop.kt
@@ -1,0 +1,18 @@
+package com.agent.code.security
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+object EmergencyStop {
+    private val _stopped = MutableStateFlow(false)
+    val stopped: StateFlow<Boolean> = _stopped.asStateFlow()
+
+    fun activate() { _stopped.value = true }
+    fun reset() { _stopped.value = false }
+    fun isStopped(): Boolean = _stopped.value
+
+    fun check() {
+        if (_stopped.value) throw IllegalStateException("Emergency stop activated")
+    }
+}

--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/GitGuard.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/GitGuard.kt
@@ -1,0 +1,55 @@
+package com.agent.code.security
+
+object GitGuard {
+    private val protectedBranches = setOf("main", "master", "release", "prod")
+
+    private val blockedSubcommands = setOf(
+        "push --force",
+        "push -f",
+        "push --force-with-lease",
+        "reset --hard",
+        "rebase --onto",
+        "filter-branch",
+        "commit --amend",
+    )
+
+    fun isAllowed(subcommand: String, args: String): GitDecision {
+        val normalized = "$subcommand $args".trim().lowercase()
+
+        for (blocked in blockedSubcommands) {
+            if (normalized.startsWith(blocked)) {
+                return GitDecision.Blocked("subcommand blocked: $blocked")
+            }
+        }
+
+        if (subcommand == "push") {
+            val targetBranch = extractTargetBranch(args)
+            if (targetBranch != null && targetBranch in protectedBranches) {
+                return GitDecision.Blocked("push to protected branch '$targetBranch' denied")
+            }
+        }
+
+        if (subcommand == "checkout" || subcommand == "switch") {
+            val target = extractTargetBranch(args)
+            if (target != null && target in protectedBranches) {
+                return GitDecision.Blocked("checkout of protected branch '$target' denied")
+            }
+        }
+
+        if (subcommand == "branch" && args.contains("-D")) {
+            return GitDecision.Blocked("force-delete branch denied")
+        }
+
+        return GitDecision.Allowed
+    }
+
+    private fun extractTargetBranch(args: String): String? {
+        val parts = args.split("\\s+".toRegex()).filter { it.isNotBlank() }
+        return parts.lastOrNull()
+    }
+}
+
+sealed interface GitDecision {
+    data object Allowed : GitDecision
+    data class Blocked(val reason: String) : GitDecision
+}


### PR DESCRIPTION
Add security layer for agent tool execution:

- EmergencyStop: singleton kill flag, check() throws on activation
- CommandAllowlist: blocks destructive shell commands (rm -rf, wget, nc, etc.)
- GitGuard: protects main/master/release/prod branches, blocks force-push, --hard reset
- AuditLog: structured audit trail of all tool executions (last 1000 entries)
- TerminalTool: integrated allowlist + emergency stop + audit logging
- GitTool: integrated git guard + emergency stop + audit logging