### PR TITLE
fix: address 6 Major AI review findings from PRs #150/#151

### DIFF
--- a/agent-core/src/commonMain/kotlin/com/agent/code/mcp/GitTool.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/mcp/GitTool.kt
@@ -21,7 +21,10 @@ class GitTool : AgentTool {
     override val riskLevel = RiskLevel.WRITE
 
     override suspend fun execute(argumentsJson: String, fileSystem: FileSystemProvider, processRunner: ProcessRunner): ToolResult {
-        EmergencyStop.check()
+        try { EmergencyStop.check() } catch (e: Exception) {
+            AuditLog.log(name, argumentsJson, false, e.message ?: "stopped", blocked = true, blockReason = "emergency stop")
+            return ToolResult(name, false, "emergency stop activated", 0L)
+        }
 
         val obj = try {
             Json.parseToJsonElement(argumentsJson).jsonObject

--- a/agent-core/src/commonMain/kotlin/com/agent/code/mcp/TerminalTool.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/mcp/TerminalTool.kt
@@ -20,7 +20,10 @@ class TerminalTool : AgentTool {
     override val riskLevel = RiskLevel.WRITE
 
     override suspend fun execute(argumentsJson: String, fileSystem: FileSystemProvider, processRunner: ProcessRunner): ToolResult {
-        EmergencyStop.check()
+        try { EmergencyStop.check() } catch (e: Exception) {
+            AuditLog.log(name, argumentsJson, false, e.message ?: "stopped", blocked = true, blockReason = "emergency stop")
+            return ToolResult(name, false, "emergency stop activated", 0L)
+        }
 
         val obj = try {
             Json.parseToJsonElement(argumentsJson).jsonObject

--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/CommandAllowlist.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/CommandAllowlist.kt
@@ -1,6 +1,11 @@
 package com.agent.code.security
 
 object CommandAllowlist {
+    private val interpreterPrefixes = setOf(
+        "sh", "bash", "zsh", "env", "eval",
+        "python", "python3", "ruby", "perl", "node", "php"
+    )
+
     private val blockedCommands = setOf(
         "rm -rf /",
         "rm -rf /*",
@@ -45,6 +50,8 @@ object CommandAllowlist {
 
     fun isAllowed(command: String): Boolean {
         val normalized = command.trim().lowercase()
+        val firstToken = normalized.split("\\s+".toRegex()).firstOrNull() ?: return false
+        if (firstToken in interpreterPrefixes) return false
         if (blockedCommands.any { normalized.startsWith(it) }) return false
         if (blockedPatterns.any { it.containsMatchIn(normalized) }) return false
         return true
@@ -52,6 +59,8 @@ object CommandAllowlist {
 
     fun reason(command: String): String? {
         val normalized = command.trim().lowercase()
+        val firstToken = normalized.split("\\s+".toRegex()).firstOrNull() ?: return null
+        if (firstToken in interpreterPrefixes) return "blocked interpreter: $firstToken"
         val blocked = blockedCommands.firstOrNull { normalized.startsWith(it) }
         if (blocked != null) return "blocked command: $blocked"
         val pattern = blockedPatterns.firstOrNull { it.containsMatchIn(normalized) }

--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/GitGuard.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/GitGuard.kt
@@ -23,14 +23,14 @@ object GitGuard {
         }
 
         if (subcommand == "push") {
-            val targetBranch = extractTargetBranch(args)
+            val targetBranch = extractPushTarget(args)
             if (targetBranch != null && targetBranch in protectedBranches) {
                 return GitDecision.Blocked("push to protected branch '$targetBranch' denied")
             }
         }
 
         if (subcommand == "checkout" || subcommand == "switch") {
-            val target = extractTargetBranch(args)
+            val target = extractCheckoutTarget(args)
             if (target != null && target in protectedBranches) {
                 return GitDecision.Blocked("checkout of protected branch '$target' denied")
             }
@@ -43,9 +43,20 @@ object GitGuard {
         return GitDecision.Allowed
     }
 
-    private fun extractTargetBranch(args: String): String? {
-        val parts = args.split("\\s+".toRegex()).filter { it.isNotBlank() }
-        return parts.lastOrNull()
+    private fun extractPushTarget(args: String): String? {
+        val parts = args.split("\\s+".toRegex()).filter { it.isNotBlank() && !it.startsWith("-") }
+        if (parts.size < 2) return parts.lastOrNull()
+        val refspec = parts.last()
+        return if (refspec.contains(":")) {
+            refspec.substringAfter(":").removePrefix("refs/heads/")
+        } else {
+            refspec.removePrefix("refs/heads/")
+        }
+    }
+
+    private fun extractCheckoutTarget(args: String): String? {
+        val parts = args.split("\\s+".toRegex()).filter { it.isNotBlank() && !it.startsWith("-") }
+        return parts.firstOrNull()
     }
 }
 

--- a/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.agent.code.core.path.VirtualPath
@@ -32,6 +33,9 @@ class MainActivity : ComponentActivity() {
                     processRunner = GitProcessRunner(),
                     workspaceRoot = workspaceRoot
                 )
+            }
+            DisposableEffect(Unit) {
+                onDispose { viewModel.destroy() }
             }
             App(
                 agentViewModel = viewModel,

--- a/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentViewModel.kt
+++ b/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentViewModel.kt
@@ -1,19 +1,19 @@
 package com.agent.code.ui
 
-import com.agent.code.core.journal.AgentEvent
 import com.agent.code.core.journal.AgentEventJournal
 import com.agent.code.core.journal.InMemoryWalStore
 import com.agent.code.core.journal.TelemetryEngine
 import com.agent.code.core.path.VirtualPath
 import com.agent.code.mcp.McpHost
 import com.agent.code.opencode.AgentBrain
-import com.agent.code.opencode.AgentConfig
 import com.agent.code.opencode.BrainEvent
 import com.agent.code.opencode.OpenCodeClient
 import com.agent.code.opencode.OpenCodeManager
 import com.agent.code.opencode.OpenCodeState
 import com.agent.code.workspace.FileSystemProvider
 import com.agent.code.workspace.ProcessRunner
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -46,7 +46,8 @@ class AgentViewModel(
     private val brain: AgentBrain,
     private val journal: AgentEventJournal,
     private val telemetry: TelemetryEngine,
-    private val workspaceRoot: VirtualPath
+    private val workspaceRoot: VirtualPath,
+    private val httpClient: HttpClient
 ) {
     private val _state = MutableStateFlow(AgentUiState())
     val state: StateFlow<AgentUiState> = _state.asStateFlow()
@@ -58,7 +59,10 @@ class AgentViewModel(
         if (statePollJob != null) return
         statePollJob = scope.launch {
             while (true) {
-                _state.value = _state.value.copy(processState = openCodeManager.currentState())
+                val s = openCodeManager.currentState()
+                if (s !is OpenCodeState.Error) {
+                    _state.value = _state.value.copy(processState = s)
+                }
                 delay(500)
             }
         }
@@ -67,6 +71,8 @@ class AgentViewModel(
                 openCodeManager.ensureInstalled()
                 openCodeManager.start(projectDir = workspaceRoot)
             } catch (e: Exception) {
+                statePollJob?.cancel()
+                statePollJob = null
                 _state.value = _state.value.copy(
                     processState = OpenCodeState.Error(e.message ?: "start failed")
                 )
@@ -115,6 +121,8 @@ class AgentViewModel(
                         _state.value = _state.value.copy(isRunning = false)
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _state.value = _state.value.copy(
                     isRunning = false,
@@ -134,6 +142,7 @@ class AgentViewModel(
         cancelTask()
         statePollJob?.cancel()
         scope.launch { openCodeManager.stop() }
+        httpClient.close()
     }
 
     companion object {
@@ -144,12 +153,13 @@ class AgentViewModel(
             workspaceRoot: VirtualPath
         ): AgentViewModel {
             val manager = OpenCodeManager(fileSystem, processRunner)
-            val client = OpenCodeClient(io.ktor.client.HttpClient(), manager)
+            val httpClient = HttpClient()
+            val client = OpenCodeClient(httpClient, manager)
             val journal = AgentEventJournal(InMemoryWalStore())
             val telemetry = TelemetryEngine(scope)
             val mcp = McpHost(fileSystem, processRunner)
             val brain = AgentBrain(client, mcp, journal, telemetry)
-            return AgentViewModel(scope, manager, client, brain, journal, telemetry, workspaceRoot)
+            return AgentViewModel(scope, manager, client, brain, journal, telemetry, workspaceRoot, httpClient)
         }
     }
 }


### PR DESCRIPTION
Fixes 6 Major severity findings from AI code review on PRs #150 and #151.

PR 150 (Phase 4 UI):
- Poll loop now skips Error state to prevent overwriting failed start
- CancellationException rethrown to preserve structured concurrency
- HttpClient stored as field, closed in destroy()
- DisposableEffect added for Activity lifecycle cleanup

PR 151 (Phase 5 Security):
- EmergencyStop.check() moved inside try/catch with audit logging
- CommandAllowlist blocks interpreter prefixes (bash, sh, env, python, etc.)
- GitGuard.extractTargetBranch handles refspecs and flags correctly