### PR TITLE
fix: job registration race and GitGuard prefix collision

### DIFF
--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/GitGuard.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/GitGuard.kt
@@ -6,6 +6,7 @@ object GitGuard {
     private val blockedSubcommands = setOf(
         "push --force",
         "push -f",
+        "push --forceall",
         "push --force-with-lease",
         "reset --hard",
         "rebase --onto",

--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/GitGuard.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/GitGuard.kt
@@ -17,7 +17,7 @@ object GitGuard {
         val normalized = "$subcommand $args".trim().lowercase()
 
         for (blocked in blockedSubcommands) {
-            if (normalized.startsWith(blocked)) {
+            if (normalized == blocked || normalized.startsWith("$blocked ") || normalized.startsWith("$blocked=")) {
                 return GitDecision.Blocked("subcommand blocked: $blocked")
             }
         }

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MultiAgentOrchestrator.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MultiAgentOrchestrator.kt
@@ -128,7 +128,11 @@ class MultiAgentOrchestrator(
                     ))
                 }
             } finally {
-                mutex.withLock { jobs.remove(taskId) }
+                // Only remove if this is still the current job (guards against taskId reuse)
+                val myJob = kotlinx.coroutines.currentCoroutineContext()[kotlinx.coroutines.Job]
+                mutex.withLock {
+                    if (jobs[taskId] === myJob) jobs.remove(taskId)
+                }
             }
         }
         mutex.withLock { jobs[taskId] = job }

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MultiAgentOrchestrator.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MultiAgentOrchestrator.kt
@@ -7,6 +7,7 @@ import com.agent.code.core.path.VirtualPath
 import com.agent.code.mcp.McpHost
 import com.agent.code.workspace.FileSystemProvider
 import com.agent.code.workspace.ProcessRunner
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
@@ -70,6 +71,10 @@ class MultiAgentOrchestrator(
         }
 
         val job = scope.launch {
+            // Check slot still exists before expensive work (handles cancelTask during launch window)
+            val slotExists = mutex.withLock { _slots.value.containsKey(taskId) }
+            if (!slotExists) return@launch
+
             try {
                 manager.ensureInstalled()
                 manager.start(projectDir = workspaceRoot)
@@ -106,6 +111,8 @@ class MultiAgentOrchestrator(
                 } finally {
                     try { httpClient.close() } catch (_: Exception) {}
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 mutex.withLock {
                     val current = _slots.value[taskId] ?: return@withLock
@@ -113,6 +120,8 @@ class MultiAgentOrchestrator(
                         state = AgentSlotState.Failed(e.message ?: "unknown error")
                     ))
                 }
+            } finally {
+                mutex.withLock { jobs.remove(taskId) }
             }
         }
         mutex.withLock { jobs[taskId] = job }

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MultiAgentOrchestrator.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MultiAgentOrchestrator.kt
@@ -62,8 +62,10 @@ class MultiAgentOrchestrator(
     }
 
     suspend fun startTask(taskId: String) {
-        val manager = mutex.withLock { managers[taskId] }
-            ?: throw IllegalStateException("No slot for task $taskId")
+        val manager = mutex.withLock {
+            if (jobs.containsKey(taskId)) throw IllegalStateException("Task $taskId is already running")
+            managers[taskId]
+        } ?: throw IllegalStateException("No slot for task $taskId")
 
         mutex.withLock {
             val slot = _slots.value[taskId] ?: return@withLock
@@ -128,10 +130,14 @@ class MultiAgentOrchestrator(
                     ))
                 }
             } finally {
-                // Only remove if this is still the current job (guards against taskId reuse)
+                // Only clean up if this is still the current job (guards against taskId reuse)
                 val myJob = kotlinx.coroutines.currentCoroutineContext()[kotlinx.coroutines.Job]
                 mutex.withLock {
-                    if (jobs[taskId] === myJob) jobs.remove(taskId)
+                    if (jobs[taskId] === myJob) {
+                        jobs.remove(taskId)
+                        managers.remove(taskId)
+                        _slots.value = _slots.value - taskId
+                    }
                 }
             }
         }

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MultiAgentOrchestrator.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MultiAgentOrchestrator.kt
@@ -77,7 +77,14 @@ class MultiAgentOrchestrator(
 
             try {
                 manager.ensureInstalled()
+                // Re-check after suspending call: cancelTask may have removed the slot
+                val stillRunning = mutex.withLock { _slots.value.containsKey(taskId) }
+                if (!stillRunning) return@launch
+
                 manager.start(projectDir = workspaceRoot)
+                // Re-check after suspending call
+                val stillRunning2 = mutex.withLock { _slots.value.containsKey(taskId) }
+                if (!stillRunning2) return@launch
 
                 val httpClient = io.ktor.client.HttpClient()
                 try {


### PR DESCRIPTION
## Changes

### MultiAgentOrchestrator — job registration race (Major)
- **Slot existence check before expensive work**: After , the coroutine now checks if the slot still exists before calling /. Handles the race where  runs during the launch window.
- **CancellationException rethrow**: Prevents structured concurrency breakage. Previously swallowed by generic .
- **Jobs map cleanup in finally**: Completed tasks now remove their job reference from the  map, preventing memory leaks.

### GitGuard — prefix collision (Minor)
- **Fixed  check**: Was  which caused false positives (e.g.,  matched ). Now uses exact match + space/equals suffix only.

## Review findings addressed
- PR #158 AI review Finding 2 (race between launch and job registration): Fixed via slot existence check
- PR #158 AI review Finding 1 (CancellationException swallowed): Fixed via explicit rethrow
- PR #158 AI review job cleanup: Fixed via finally block
- PR #151 AI review Finding 8 (GitGuard prefix collision): Fixed