### PR TITLE
feat: persist AuditLog to disk for forensic analysis

### DIFF
--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -27,6 +29,7 @@ object AuditLog {
     private val maxEntries = 1000
     private val json = Json { ignoreUnknownKeys = true }
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val fileMutex = Mutex()
 
     private var fileSystem: FileSystemProvider? = null
     private var logPath: VirtualPath? = null
@@ -68,10 +71,12 @@ object AuditLog {
         val fs = fileSystem ?: return
         val path = logPath ?: return
         scope.launch {
-            runCatching {
-                val line = json.encodeToString(entry) + "\n"
-                val existing = fs.read(path).getOrNull() ?: ""
-                fs.write(path, existing + line)
+            fileMutex.withLock {
+                runCatching {
+                    val line = json.encodeToString(entry) + "\n"
+                    val existing = fs.read(path).getOrNull() ?: ""
+                    fs.write(path, existing + line)
+                }
             }
         }
     }

--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
@@ -1,7 +1,15 @@
 package com.agent.code.security
 
+import com.agent.code.core.path.VirtualPath
+import com.agent.code.workspace.FileSystemProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 @Serializable
 data class AuditEntry(
@@ -17,12 +25,53 @@ data class AuditEntry(
 object AuditLog {
     private val entries = mutableListOf<AuditEntry>()
     private val maxEntries = 1000
+    private val json = Json { ignoreUnknownKeys = true }
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private var fileSystem: FileSystemProvider? = null
+    private var logPath: VirtualPath? = null
+
+    fun init(fileSystem: FileSystemProvider?, logDir: VirtualPath?) {
+        this.fileSystem = fileSystem
+        this.logPath = logDir?.resolve("audit-log.jsonl")
+        if (fileSystem != null && logPath != null) {
+            scope.launch { load() }
+        }
+    }
+
+    private suspend fun load() {
+        val fs = fileSystem ?: return
+        val path = logPath ?: return
+        runCatching {
+            val content = fs.read(path).getOrNull() ?: return
+            synchronized(entries) {
+                content.lines().filter { it.isNotBlank() }.forEach { line ->
+                    runCatching {
+                        entries.add(json.decodeFromString<AuditEntry>(line))
+                    }
+                }
+            }
+        }
+    }
 
     fun record(entry: AuditEntry) {
         synchronized(entries) {
             entries.add(entry)
             if (entries.size > maxEntries) {
                 entries.removeAt(0)
+            }
+        }
+        persistEntry(entry)
+    }
+
+    private fun persistEntry(entry: AuditEntry) {
+        val fs = fileSystem ?: return
+        val path = logPath ?: return
+        scope.launch {
+            runCatching {
+                val line = json.encodeToString(entry) + "\n"
+                val existing = fs.read(path).getOrNull() ?: ""
+                fs.write(path, existing + line)
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
@@ -11,6 +11,7 @@ import com.agent.code.core.path.VirtualPath
 import com.agent.code.core.power.AndroidPowerGovernor
 import com.agent.code.service.ResilientAgentForegroundService
 import com.agent.code.ui.AgentViewModel
+import com.agent.code.security.AuditLog
 import com.agent.code.workspace.RealFileSystem
 import com.agent.code.workspace.GitProcessRunner
 
@@ -23,13 +24,15 @@ class MainActivity : ComponentActivity() {
         ResilientAgentForegroundService.start(this)
 
         val workspaceRoot = VirtualPath.of(filesDir.absolutePath)
+        val fileSystem = RealFileSystem(workspaceRoot)
+        AuditLog.init(fileSystem, workspaceRoot)
 
         setContent {
             val scope = rememberCoroutineScope()
             val viewModel = remember {
                 AgentViewModel.create(
                     scope = scope,
-                    fileSystem = RealFileSystem(workspaceRoot),
+                    fileSystem = fileSystem,
                     processRunner = GitProcessRunner(),
                     workspaceRoot = workspaceRoot
                 )


### PR DESCRIPTION
## What
- Inject FileSystemProvider + VirtualPath into AuditLog.init()
- Append JSONL on each record() via background coroutine
- Load existing entries on init()
- Backward compatible: no persistence if init() not called

## Why
AuditLog was in-memory only. forensic analysis requires persistence across app restarts.

## How
- JSONL file at 
- Background coroutine for non-blocking writes
- Load on startup via scope.launch
- clear() only clears in-memory (next record overwrites file)

Fixes #154