### PR TITLE
fix: convergence message says 'no NEW Major findings'

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -275,7 +275,7 @@ jobs:
             fi
 
             if [ "$MAJOR_COUNT" -eq 0 ] && [ "$ROUND" -gt 1 ]; then
-              CONVERGENCE_REASON="no Major findings in round $ROUND"
+              CONVERGENCE_REASON="no NEW Major findings in round $ROUND"
               break
             fi
 


### PR DESCRIPTION
The review loop convergence message said 'no Major findings in round X' which was misleading — it meant no NEW Major findings in that round, but accumulated findings still contained Major from earlier rounds. Changed to 'no NEW Major findings' for clarity.