### PR TITLE
fix: default PUSHED to 'none' in comment step

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -275,7 +275,7 @@ jobs:
             fi
 
             if [ "$MAJOR_COUNT" -eq 0 ] && [ "$ROUND" -gt 1 ]; then
-              CONVERGENCE_REASON="no Major findings in round $ROUND"
+              CONVERGENCE_REASON="no NEW Major findings in round $ROUND"
               break
             fi
 
@@ -605,7 +605,7 @@ jobs:
           PUSHED: ${{ steps.commit.outputs.pushed }}
           REASON: ${{ steps.commit.outputs.reason }}
         run: |
-          PUSHED="${PUSHED:-}"
+          PUSHED="${PUSHED:-none}"
           B="## AI Fix Results"
           if [ "$PUSHED" = "true" ]; then
             FILES=$(git show --pretty=format: --name-only HEAD | sed '/^$/d')


### PR DESCRIPTION
The commit step writes `pushed=none` via GITHUB_OUTPUT on early-exit paths, but the comment step sometimes sees `PUSHED` as empty. Defaulting to `"none"` ensures the comment logic treats missing outputs correctly instead of falling through to the "push failed" branch.

Fixes the fix job comment misreporting on PR #162.