### PR TITLE
fix: AuditLog review findings — volatile, init race, persistEntry data loss

### DIFF
--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
@@ -37,19 +37,24 @@ object AuditLog {
     @Volatile
     private var logPath: VirtualPath? = null
 
+    @Volatile
     private var loaded = CompletableDeferred<Unit>()
 
     fun init(fileSystem: FileSystemProvider?, logDir: VirtualPath?) {
+        val oldDeferred = loaded
         loaded = CompletableDeferred()
         this.fileSystem = fileSystem
         this.logPath = logDir?.resolve("audit-log.jsonl")
         if (fileSystem != null && logPath != null) {
+            val deferred = loaded
             scope.launch {
                 load()
-                loaded.complete(Unit)
+                deferred.complete(Unit)
+                oldDeferred.complete(Unit)
             }
         } else {
             loaded.complete(Unit)
+            oldDeferred.complete(Unit)
         }
     }
 
@@ -83,10 +88,12 @@ object AuditLog {
         val fs = fileSystem ?: return
         val path = logPath ?: return
         fileMutex.withLock {
-            runCatching {
-                val line = json.encodeToString(entry) + "\n"
-                val existing = fs.read(path).getOrNull() ?: return
+            val line = json.encodeToString(entry) + "\n"
+            val existing = fs.read(path).getOrNull()
+            if (existing != null) {
                 fs.write(path, existing + line)
+            } else {
+                fs.write(path, line)
             }
         }
     }


### PR DESCRIPTION
## What
- Add `@Volatile` to `loaded` for cross-thread visibility
- Capture deferred reference before launch in `init()`
- Complete old deferred on re-init to prevent permanent hang
- On read failure, write entry standalone instead of silently dropping

## Why
AI review on PR #160 found 4 Major findings:
1. `loaded` missing `@Volatile` — coroutine threads may never see updated deferred
2. `init()` re-entrance race — wrong CompletableDeferred completed
3. `persistEntry` silently drops entries on file read failure — data loss
4. Double-init abandons old deferred — permanent hang

PR #162 was merged before these fixes were pushed. This PR applies them to main.