### PR TITLE
feat: Android MVP — mock agent, clean UI, AuditLog hardened

### DIFF
--- a/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/security/AuditLog.kt
@@ -14,6 +14,7 @@ import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.io.IOException
 
 @Serializable
 data class AuditEntry(
@@ -69,11 +70,11 @@ object AuditLog {
     private suspend fun load(fs: FileSystemProvider, path: VirtualPath) {
         runCatching {
             val content = fs.read(path).getOrNull() ?: ""
-            fileContent = content
             val parsed = content.lines().filter { it.isNotBlank() }.mapNotNull { line ->
                 runCatching { json.decodeFromString<AuditEntry>(line) }.getOrNull()
             }
-            synchronized(entries) {
+            fileMutex.withLock {
+                fileContent = content
                 entries.clear()
                 entries.addAll(parsed)
             }
@@ -101,7 +102,7 @@ object AuditLog {
                 fs.write(path, fileContent)
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Exception) {
+            } catch (_: IOException) {
                 // I/O failure — entry exists in memory only
             }
         }
@@ -135,7 +136,16 @@ object AuditLog {
     }
 
     fun clear() {
-        synchronized(entries) { entries.clear() }
-        fileContent = ""
+        val fs = fileSystem ?: return
+        val path = logPath ?: return
+        scope.launch {
+            fileMutex.withLock {
+                entries.clear()
+                fileContent = ""
+                try {
+                    fs.write(path, "")
+                } catch (_: IOException) {}
+            }
+        }
     }
 }

--- a/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.agent.code.core.path.VirtualPath
@@ -39,6 +40,9 @@ class MainActivity : ComponentActivity() {
             }
             DisposableEffect(Unit) {
                 onDispose { viewModel.destroy() }
+            }
+            LaunchedEffect(Unit) {
+                viewModel.startOpenCode()
             }
             App(
                 agentViewModel = viewModel,

--- a/app-ui/src/commonMain/kotlin/com/agent/code/App.kt
+++ b/app-ui/src/commonMain/kotlin/com/agent/code/App.kt
@@ -1,183 +1,29 @@
 package com.agent.code
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.Button
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import com.agent.code.bootstrap.MissionControlBootstrap
-import com.agent.code.bootstrap.Timeline
-import com.agent.code.core.journal.LogEntry
-import com.agent.code.core.journal.TelemetryEngine
-import com.agent.code.core.power.PowerGovernor
-import com.agent.code.core.power.StubPowerGovernor
-import com.agent.code.provider.HierarchicalModelRouter
 import com.agent.code.ui.AgentPanel
 import com.agent.code.ui.AgentViewModel
-import com.agent.code.ui.DashboardScreen
-import com.agent.code.ui.demoModelRouter
-import kotlinx.coroutines.launch
 
 @Composable
-@Preview
 fun App(
-    probeDashboard: @Composable (() -> Unit)? = null,
-    governor: PowerGovernor = StubPowerGovernor(),
     agentViewModel: AgentViewModel? = null,
 ) {
     MaterialTheme {
-        var showSpine by remember { mutableStateOf(false) }
-        var showDash by remember { mutableStateOf(false) }
-        var showAgent by remember { mutableStateOf(agentViewModel != null) }
-        val telemetry = remember { TelemetryEngine() }
-        val router: HierarchicalModelRouter = remember { demoModelRouter() }
-
         Column(
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.primaryContainer)
-                .safeContentPadding()
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState()),
+                .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (agentViewModel != null) {
-                Button(onClick = { showAgent = !showAgent }) {
-                    Text("M6 Agent")
-                }
-                AnimatedVisibility(showAgent) {
-                    AgentPanel(viewModel = agentViewModel)
-                }
-            }
-            Button(onClick = { showSpine = !showSpine }) {
-                Text("M0.5 Spine Demo")
-            }
-            AnimatedVisibility(showSpine) {
-                M05SpineDemo()
-            }
-            Button(onClick = { showDash = !showDash }) {
-                Text("M3 Live Dashboard")
-            }
-            AnimatedVisibility(showDash) {
-                DashboardScreen(telemetry = telemetry, governor = governor, router = router)
-            }
-            probeDashboard?.invoke()
-        }
-    }
-}
-
-/**
- * Barebones harness that runs the M0.5 bootstrap spine on the real runtime and
- * renders the resulting [Timeline]. Proves the WAL-recovery invariant
- * (finalState == recoveredState) and the orchestration spine end-to-end.
- * Stubbed subsystems (LLM/MCP/process) are not exercised here.
- */
-@Composable
-fun M05SpineDemo() {
-    val clipboard = LocalClipboardManager.current
-    val scope = rememberCoroutineScope()
-    var timeline by remember { mutableStateOf<Timeline?>(null) }
-    var spineError by remember { mutableStateOf<String?>(null) }
-    var copied by remember { mutableStateOf(false) }
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Button(onClick = {
-            spineError = null
-            scope.launch {
-                try { timeline = MissionControlBootstrap.runDemo() }
-                catch (e: Exception) { spineError = "${e::class.simpleName}: ${e.message}" }
-            }
-        }) {
-            Text("Run M0.5 Demo")
-        }
-        spineError?.let {
-            Text("Error: $it", color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
-        }
-        timeline?.let { tl ->
-            val recovered = tl.finalState == tl.recoveredState
-            // Fixed summary — stays pinned so the recovery verdict is always visible.
-            Text(
-                text = if (recovered) "WAL recovery: OK (identical)" else "WAL recovery: MISMATCH",
-                fontWeight = FontWeight.Bold,
-            )
-            Text("Final state: ${tl.finalState}")
-            Text("Recovered state: ${tl.recoveredState}")
-            Text("Events: ${tl.events.size}  |  Telemetry frames: ${tl.telemetryFrames.size}")
-            Button(onClick = {
-                clipboard.setText(AnnotatedString(buildLogDump(tl)))
-                copied = true
-            }) {
-                Text(if (copied) "Copied!" else "Copy logs")
-            }
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-            // Stream 1 — the durable WAL event journal.
-            Text("Event journal (WAL)", fontWeight = FontWeight.Bold)
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth(),
-            ) {
-                tl.events.forEach { Text("• $it") }
-            }
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-            // Stream 2 — the 50ms telemetry sampling engine's frames.
-            Text("Telemetry frames (50ms engine)", fontWeight = FontWeight.Bold)
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth(),
-            ) {
-                tl.telemetryFrames.forEachIndexed { i, frame ->
-                    Text("Frame $i (${frame.size})", fontWeight = FontWeight.Bold)
-                    frame.forEach { Text("  ${logEntryLine(it)}") }
-                }
+                AgentPanel(viewModel = agentViewModel)
             }
         }
     }
-}
-
-/** Plain-text dump of the whole timeline for clipboard export. */
-private fun buildLogDump(tl: Timeline): String = buildString {
-    appendLine("M0.5 Spine Demo — Timeline dump")
-    appendLine("WAL recovery: ${if (tl.finalState == tl.recoveredState) "OK (identical)" else "MISMATCH"}")
-    appendLine("Final state: ${tl.finalState}")
-    appendLine("Recovered state: ${tl.recoveredState}")
-    appendLine("Events: ${tl.events.size} | Telemetry frames: ${tl.telemetryFrames.size}")
-    appendLine()
-    appendLine("== Event journal (WAL) ==")
-    tl.events.forEach { appendLine("• $it") }
-    appendLine()
-    appendLine("== Telemetry frames (50ms engine) ==")
-    tl.telemetryFrames.forEachIndexed { i, frame ->
-        appendLine("Frame $i (${frame.size})")
-        frame.forEach { appendLine("  ${logEntryLine(it)}") }
-    }
-}
-
-/** One-line rendering of a telemetry [LogEntry]. */
-private fun logEntryLine(e: LogEntry): String {
-    val body = when (e) {
-        is LogEntry.AgentThought -> e.markdown
-        is LogEntry.ToolCallStarted -> "tool=${e.toolName} args=${e.args}"
-        is LogEntry.TerminalStream -> "${if (e.isError) "ERR " else ""}${e.line}"
-        is LogEntry.SystemWarning -> e.message
-    }
-    return "[${e.timestampMs}] $body"
 }

--- a/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentViewModel.kt
+++ b/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentViewModel.kt
@@ -7,16 +7,16 @@ import com.agent.code.core.path.VirtualPath
 import com.agent.code.mcp.McpHost
 import com.agent.code.opencode.AgentBrain
 import com.agent.code.opencode.BrainEvent
-import com.agent.code.opencode.OpenCodeClient
+import com.agent.code.opencode.OpenCodeApi
 import com.agent.code.opencode.OpenCodeManager
 import com.agent.code.opencode.OpenCodeState
+import com.agent.code.opencode.MockOpenCodeClient
 import com.agent.code.workspace.FileSystemProvider
 import com.agent.code.workspace.ProcessRunner
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,7 +42,7 @@ sealed interface UiEvent {
 class AgentViewModel(
     private val scope: CoroutineScope,
     private val openCodeManager: OpenCodeManager,
-    private val openCodeClient: OpenCodeClient,
+    private val openCodeClient: OpenCodeApi,
     private val brain: AgentBrain,
     private val journal: AgentEventJournal,
     private val telemetry: TelemetryEngine,
@@ -53,40 +53,13 @@ class AgentViewModel(
     val state: StateFlow<AgentUiState> = _state.asStateFlow()
 
     private var brainJob: Job? = null
-    private var statePollJob: Job? = null
 
     fun startOpenCode() {
-        if (statePollJob != null) return
-        statePollJob = scope.launch {
-            while (true) {
-                val s = openCodeManager.currentState()
-                if (s !is OpenCodeState.Error) {
-                    _state.value = _state.value.copy(processState = s)
-                }
-                delay(500)
-            }
-        }
-        scope.launch {
-            try {
-                openCodeManager.ensureInstalled()
-                openCodeManager.start(projectDir = workspaceRoot)
-            } catch (e: Exception) {
-                statePollJob?.cancel()
-                statePollJob = null
-                _state.value = _state.value.copy(
-                    processState = OpenCodeState.Error(e.message ?: "start failed")
-                )
-            }
-        }
+        _state.value = _state.value.copy(processState = OpenCodeState.Running(4096, 0))
     }
 
     fun stopOpenCode() {
-        statePollJob?.cancel()
-        statePollJob = null
-        scope.launch {
-            openCodeManager.stop()
-            _state.value = _state.value.copy(processState = OpenCodeState.Stopped)
-        }
+        _state.value = _state.value.copy(processState = OpenCodeState.Stopped)
     }
 
     fun executeTask(goal: String) {
@@ -140,8 +113,6 @@ class AgentViewModel(
 
     fun destroy() {
         cancelTask()
-        statePollJob?.cancel()
-        scope.launch { openCodeManager.stop() }
         httpClient.close()
     }
 
@@ -154,7 +125,7 @@ class AgentViewModel(
         ): AgentViewModel {
             val manager = OpenCodeManager(fileSystem, processRunner)
             val httpClient = HttpClient()
-            val client = OpenCodeClient(httpClient, manager)
+            val client: OpenCodeApi = MockOpenCodeClient()
             val journal = AgentEventJournal(InMemoryWalStore())
             val telemetry = TelemetryEngine(scope)
             val mcp = McpHost(fileSystem, processRunner)

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/AgentBrain.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/AgentBrain.kt
@@ -39,7 +39,7 @@ sealed interface BrainEvent {
 }
 
 class AgentBrain(
-    private val client: OpenCodeClient,
+    private val client: OpenCodeApi,
     private val mcp: McpHost,
     private val journal: AgentEventJournal,
     private val telemetry: TelemetryEngine,

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MockOpenCodeClient.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MockOpenCodeClient.kt
@@ -1,0 +1,42 @@
+package com.agent.code.opencode
+
+import com.agent.code.provider.LlmEvent
+import com.agent.code.provider.LlmRequest
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class MockOpenCodeClient : OpenCodeApi {
+    private var callCount = 0
+
+    override suspend fun healthCheck(): Result<String> = Result.success("Mock running")
+
+    override suspend fun sendChat(request: LlmRequest): String {
+        callCount++
+        return if (callCount <= 1) {
+            """{"tool_calls":[{"id":"tc-1","name":"read_file","arguments":"{\"path\":\"README.md\"}"}]}"""
+        } else {
+            """{"done":true,"summary":"Mock task complete"}"""
+        }
+    }
+
+    override fun streamChat(request: LlmRequest): Flow<LlmEvent> = flow {
+        callCount++
+        if (callCount <= 1) {
+            emit(LlmEvent.ReasoningChunk("Thinking about the task...\n"))
+            delay(100)
+            emit(LlmEvent.ToolCallChunk("tc-1", "read_file", """{"path":"README.md"}"""))
+            delay(50)
+            emit(LlmEvent.UsageReport(100, 50))
+        } else {
+            emit(LlmEvent.ContentChunk("Done. "))
+            delay(50)
+            emit(LlmEvent.ContentChunk("""{"done":true,"summary":"Mock task complete"}"""))
+            delay(50)
+            emit(LlmEvent.UsageReport(80, 30))
+        }
+    }
+
+    override suspend fun listSessions(): List<String> = emptyList()
+    override suspend fun listModels(): List<String> = listOf("mock-model")
+}

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeApi.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeApi.kt
@@ -1,0 +1,13 @@
+package com.agent.code.opencode
+
+import com.agent.code.provider.LlmEvent
+import com.agent.code.provider.LlmRequest
+import kotlinx.coroutines.flow.Flow
+
+interface OpenCodeApi {
+    suspend fun healthCheck(): Result<String>
+    suspend fun sendChat(request: LlmRequest): String
+    fun streamChat(request: LlmRequest): Flow<LlmEvent>
+    suspend fun listSessions(): List<String>
+    suspend fun listModels(): List<String>
+}

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeClient.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeClient.kt
@@ -25,8 +25,8 @@ import kotlinx.serialization.json.jsonPrimitive
 class OpenCodeClient(
     private val httpClient: HttpClient,
     private val manager: OpenCodeManager
-) {
-    suspend fun healthCheck(): Result<String> {
+) : OpenCodeApi {
+    override suspend fun healthCheck(): Result<String> {
         return try {
             val response = httpClient.get("${manager.baseUrl()}/api/health")
             if (response.status != io.ktor.http.HttpStatusCode.OK) {
@@ -41,7 +41,7 @@ class OpenCodeClient(
         }
     }
 
-    suspend fun sendChat(request: LlmRequest): String {
+    override suspend fun sendChat(request: LlmRequest): String {
         val body = buildJsonObject {
             put("model", JsonPrimitive(request.modelId))
             put("messages", buildJsonArray {
@@ -63,7 +63,7 @@ class OpenCodeClient(
         return response.bodyAsText()
     }
 
-    fun streamChat(request: LlmRequest): Flow<LlmEvent> = flow {
+    override fun streamChat(request: LlmRequest): Flow<LlmEvent> = flow {
         val body = buildJsonObject {
             put("model", JsonPrimitive(request.modelId))
             put("stream", JsonPrimitive(true))
@@ -109,7 +109,7 @@ class OpenCodeClient(
         }
     }
 
-    suspend fun listSessions(): List<String> {
+    override suspend fun listSessions(): List<String> {
         return try {
             val response = httpClient.get("${manager.baseUrl()}/api/sessions")
             val text = response.bodyAsText()
@@ -120,7 +120,7 @@ class OpenCodeClient(
         }
     }
 
-    suspend fun listModels(): List<String> {
+    override suspend fun listModels(): List<String> {
         return try {
             val response = httpClient.get("${manager.baseUrl()}/api/models")
             val text = response.bodyAsText()


### PR DESCRIPTION
## What
- **MockOpenCodeClient**: simulates LLM responses for end-to-end UI testing without external server
- **OpenCodeApi interface**: decouples AgentBrain from concrete OpenCodeClient — enables mock/real swap
- **App.kt**: removed M0.5 Spine Demo and M3 Live Dashboard panels — Agent is now the only view
- **AgentViewModel**: simplified — no more OpenCodeManager install/start, auto-starts mock on launch
- **MainActivity**: auto-starts agent via LaunchedEffect — user sees "Running" immediately
- **AuditLog fixes**: #178 fileContent race (inside fileMutex), #179 clear() persists to disk, #180 catch narrowed to IOException, #181 re-init race fixed

## Why
OpenCode has no standalone server binary — releases are desktop Electron apps. Mock client enables full UI flow testing. Clean UI focuses on agent as primary use case.

## How
- OpenCodeApi interface extracted from OpenCodeClient — AgentBrain now depends on interface
- MockOpenCodeClient returns simulated tool calls + done response
- AgentViewModel.startOpenCode() directly sets Running state (no process management)
- AuditLog all 4 remaining issues fixed in single pass