### PR TITLE
feat: download OpenCode from release

### DIFF
--- a/agent-core/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeManager.kt
+++ b/agent-core/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeManager.kt
@@ -3,20 +3,27 @@ package com.agent.code.opencode
 import com.agent.code.core.path.VirtualPath
 import com.agent.code.workspace.FileSystemProvider
 import com.agent.code.workspace.ProcessRunner
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.zip.GZIPInputStream
 
 data class OpenCodeConfig(
     val installDir: VirtualPath = VirtualPath.of("/data/data/com.agent.code/files/opencode"),
     val binaryName: String = "opencode",
     val defaultPort: Int = 4096,
-    val startupTimeoutMs: Long = 15_000L
+    val startupTimeoutMs: Long = 15_000L,
+    val releaseUrl: String = "https://github.com/Aderon3D/AgentCode/releases/download/opencode-binary"
 )
 
 sealed interface OpenCodeState {
     data object NotInstalled : OpenCodeState
-    data object Installing : OpenCodeState
+    data class Installing(val progress: Float = 0f, val message: String = "") : OpenCodeState
     data object Starting : OpenCodeState
     data class Running(val port: Int, val pid: Int) : OpenCodeState
     data class Error(val message: String) : OpenCodeState
@@ -47,20 +54,95 @@ class OpenCodeManager(
             return _state
         }
 
-        _state = OpenCodeState.Installing
-        val dir = config.installDir.rawPath
-        val result = processRunner.run(listOf(
-            "sh", "-c",
-            "mkdir -p '${dir}' && " +
-            "curl -fsSL https://opencode.ai/install.sh | " +
-            "BINDIR='${dir}' sh"
-        ))
-        _state = if (result.isSuccess) {
-            OpenCodeState.Stopped
-        } else {
-            OpenCodeState.Error("Install failed: ${result.getOrElse { "" }}")
+        _state = OpenCodeState.Installing(0f, "Downloading OpenCode...")
+        return try {
+            downloadAndExtract()
+            _state = OpenCodeState.Stopped
+            _state
+        } catch (e: Exception) {
+            _state = OpenCodeState.Error("Install failed: ${e.message}")
+            _state
         }
-        return _state
+    }
+
+    private suspend fun downloadAndExtract() = withContext(Dispatchers.IO) {
+        val installDir = File(config.installDir.rawPath)
+        val glibcDir = File(installDir, "glibc")
+        installDir.mkdirs()
+        glibcDir.mkdirs()
+
+        // Download and extract glibc libs
+        val glibcFiles = listOf(
+            "ld-linux-aarch64.so.1",
+            "libc.so.6",
+            "libpthread.so.0",
+            "libdl.so.2"
+        )
+
+        glibcFiles.forEachIndexed { index, name ->
+            _state = OpenCodeState.Installing(
+                (index + 1).toFloat() / (glibcFiles.size + 1),
+                "Downloading $name..."
+            )
+            val dest = File(glibcDir, name)
+            downloadFile("${config.releaseUrl}/$name", dest)
+        }
+
+        // Download and extract opencode binary (gzipped)
+        _state = OpenCodeState.Installing(0.8f, "Downloading opencode binary...")
+        val gzFile = File(installDir, "${config.binaryName}.gz")
+        downloadFile("${config.releaseUrl}/opencode.gz", gzFile)
+
+        _state = OpenCodeState.Installing(0.9f, "Extracting binary...")
+        val binaryDest = File(installDir, config.binaryName)
+        gzFile.inputStream().use { gzInput ->
+            GZIPInputStream(gzInput).use { input ->
+                binaryDest.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+        gzFile.delete()
+        binaryDest.setExecutable(true)
+
+        _state = OpenCodeState.Installing(0.95f, "Setting up wrapper...")
+        createWrapper(installDir)
+
+        _state = OpenCodeState.Installing(1.0f, "Ready")
+    }
+
+    private fun downloadFile(url: String, dest: File) {
+        val conn = URL(url).openConnection() as HttpURLConnection
+        conn.connectTimeout = 30_000
+        conn.readTimeout = 60_000
+        conn.connect()
+
+        conn.inputStream.use { input ->
+            dest.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+
+    private fun createWrapper(installDir: File) {
+        val wrapper = File(installDir, "run-opencode.sh")
+        val installPath = installDir.absolutePath
+        val binaryName = config.binaryName
+        wrapper.writeText("#!/bin/sh\n" +
+            "_INSTALL_DIR=\"$installPath\"\n" +
+            "_GLIBC_DIR=\"\$_INSTALL_DIR/glibc\"\n" +
+            "_BIN=\"\$_INSTALL_DIR/$binaryName\"\n" +
+            "\n" +
+            "# Sanitize LD_LIBRARY_PATH (remove Android bionic libs that break glibc)\n" +
+            "if [ -n \"\$LD_LIBRARY_PATH\" ]; then\n" +
+            "    LD_LIBRARY_PATH=\$(printf '%s' \"\$LD_LIBRARY_PATH\" | tr ':' '\\n' | grep -v \"^/data/user/.*com.m4coding.ide/files/support\\\$\" | paste -sd:)\n" +
+            "    export LD_LIBRARY_PATH\n" +
+            "fi\n" +
+            "\n" +
+            "exec \"\$_GLIBC_DIR/ld-linux-aarch64.so.1\" \\\n" +
+            "     --library-path \"\$_GLIBC_DIR:/system/lib64:/apex/com.android.runtime/lib64\" \\\n" +
+            "     \"\$_BIN\" \"\$@\"\n")
+        wrapper.setExecutable(true)
     }
 
     suspend fun start(
@@ -69,8 +151,8 @@ class OpenCodeManager(
     ): OpenCodeState = stateMutex.withLock {
         if (_state is OpenCodeState.Running) return@withLock _state
 
-        val binaryPath = config.installDir.resolve(config.binaryName)
-        if (!fileSystem.exists(binaryPath)) {
+        val wrapperPath = config.installDir.resolve("run-opencode.sh")
+        if (!fileSystem.exists(wrapperPath)) {
             val installed = ensureInstalledInternal()
             if (installed is OpenCodeState.Error) return@withLock installed
         }
@@ -82,7 +164,7 @@ class OpenCodeManager(
         val logFile = config.installDir.resolve("opencode.log")
 
         val cmd = "cd '${projectDir.rawPath}' && " +
-            "'${binaryPath.rawPath}' serve " +
+            "sh '${wrapperPath.rawPath}' serve " +
             "--port $port " +
             "--pid-file '${pidFile.rawPath}' " +
             "> '${logFile.rawPath}' 2>&1 & " +

--- a/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/agent/code/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.agent.code.core.path.VirtualPath
@@ -39,6 +40,9 @@ class MainActivity : ComponentActivity() {
             }
             DisposableEffect(Unit) {
                 onDispose { viewModel.destroy() }
+            }
+            LaunchedEffect(Unit) {
+                viewModel.startOpenCode()
             }
             App(
                 agentViewModel = viewModel,

--- a/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentViewModel.kt
+++ b/app-ui/src/commonMain/kotlin/com/agent/code/ui/AgentViewModel.kt
@@ -7,9 +7,11 @@ import com.agent.code.core.path.VirtualPath
 import com.agent.code.mcp.McpHost
 import com.agent.code.opencode.AgentBrain
 import com.agent.code.opencode.BrainEvent
+import com.agent.code.opencode.OpenCodeApi
 import com.agent.code.opencode.OpenCodeClient
 import com.agent.code.opencode.OpenCodeManager
 import com.agent.code.opencode.OpenCodeState
+import com.agent.code.opencode.MockOpenCodeClient
 import com.agent.code.workspace.FileSystemProvider
 import com.agent.code.workspace.ProcessRunner
 import io.ktor.client.HttpClient
@@ -42,7 +44,7 @@ sealed interface UiEvent {
 class AgentViewModel(
     private val scope: CoroutineScope,
     private val openCodeManager: OpenCodeManager,
-    private val openCodeClient: OpenCodeClient,
+    private val openCodeClient: OpenCodeApi,
     private val brain: AgentBrain,
     private val journal: AgentEventJournal,
     private val telemetry: TelemetryEngine,

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MockOpenCodeClient.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/MockOpenCodeClient.kt
@@ -1,0 +1,42 @@
+package com.agent.code.opencode
+
+import com.agent.code.provider.LlmEvent
+import com.agent.code.provider.LlmRequest
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class MockOpenCodeClient : OpenCodeApi {
+    private var callCount = 0
+
+    override suspend fun healthCheck(): Result<String> = Result.success("Mock running")
+
+    override suspend fun sendChat(request: LlmRequest): String {
+        callCount++
+        return if (callCount <= 1) {
+            """{"tool_calls":[{"id":"tc-1","name":"read_file","arguments":"{\"path\":\"README.md\"}"}]}"""
+        } else {
+            """{"done":true,"summary":"Mock task complete"}"""
+        }
+    }
+
+    override fun streamChat(request: LlmRequest): Flow<LlmEvent> = flow {
+        callCount++
+        if (callCount <= 1) {
+            emit(LlmEvent.ReasoningChunk("Thinking about the task...\n"))
+            delay(100)
+            emit(LlmEvent.ToolCallChunk("tc-1", "read_file", """{"path":"README.md"}"""))
+            delay(50)
+            emit(LlmEvent.UsageReport(100, 50))
+        } else {
+            emit(LlmEvent.ContentChunk("Done. "))
+            delay(50)
+            emit(LlmEvent.ContentChunk("""{"done":true,"summary":"Mock task complete"}"""))
+            delay(50)
+            emit(LlmEvent.UsageReport(80, 30))
+        }
+    }
+
+    override suspend fun listSessions(): List<String> = emptyList()
+    override suspend fun listModels(): List<String> = listOf("mock-model")
+}

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeApi.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeApi.kt
@@ -1,0 +1,13 @@
+package com.agent.code.opencode
+
+import com.agent.code.provider.LlmEvent
+import com.agent.code.provider.LlmRequest
+import kotlinx.coroutines.flow.Flow
+
+interface OpenCodeApi {
+    suspend fun healthCheck(): Result<String>
+    suspend fun sendChat(request: LlmRequest): String
+    fun streamChat(request: LlmRequest): Flow<LlmEvent>
+    suspend fun listSessions(): List<String>
+    suspend fun listModels(): List<String>
+}

--- a/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeClient.kt
+++ b/provider-subsystem/src/commonMain/kotlin/com/agent/code/opencode/OpenCodeClient.kt
@@ -25,8 +25,8 @@ import kotlinx.serialization.json.jsonPrimitive
 class OpenCodeClient(
     private val httpClient: HttpClient,
     private val manager: OpenCodeManager
-) {
-    suspend fun healthCheck(): Result<String> {
+) : OpenCodeApi {
+    override suspend fun healthCheck(): Result<String> {
         return try {
             val response = httpClient.get("${manager.baseUrl()}/api/health")
             if (response.status != io.ktor.http.HttpStatusCode.OK) {
@@ -41,7 +41,7 @@ class OpenCodeClient(
         }
     }
 
-    suspend fun sendChat(request: LlmRequest): String {
+    override suspend fun sendChat(request: LlmRequest): String {
         val body = buildJsonObject {
             put("model", JsonPrimitive(request.modelId))
             put("messages", buildJsonArray {
@@ -63,7 +63,7 @@ class OpenCodeClient(
         return response.bodyAsText()
     }
 
-    fun streamChat(request: LlmRequest): Flow<LlmEvent> = flow {
+    override fun streamChat(request: LlmRequest): Flow<LlmEvent> = flow {
         val body = buildJsonObject {
             put("model", JsonPrimitive(request.modelId))
             put("stream", JsonPrimitive(true))
@@ -109,7 +109,7 @@ class OpenCodeClient(
         }
     }
 
-    suspend fun listSessions(): List<String> {
+    override suspend fun listSessions(): List<String> {
         return try {
             val response = httpClient.get("${manager.baseUrl()}/api/sessions")
             val text = response.bodyAsText()
@@ -120,7 +120,7 @@ class OpenCodeClient(
         }
     }
 
-    suspend fun listModels(): List<String> {
+    override suspend fun listModels(): List<String> {
         return try {
             val response = httpClient.get("${manager.baseUrl()}/api/models")
             val text = response.bodyAsText()


### PR DESCRIPTION
## What
OpenCode binary (176MB) too large for git blobs. Switch to GitHub release download.

## Changes
- OpenCodeManager downloads from release on first launch
- Decompresses .gz at runtime
- Glibc libs downloaded alongside binary
- No more assets/ directory in APK
- Simplified MultiAgentOrchestrator (removed assetReader)
- Simplified AgentViewModel/MainActivity (no assetReader param)