### PR TITLE
fix: AI review posts blocking PR reviews

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -338,27 +338,28 @@ jobs:
           # Count findings
           HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:' || true)
 
-          # Fetch the current SHA for the review
-          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha') || {
-            echo "Failed to fetch PR head SHA" >&2
-            exit 1
-          }
-
           if [ "${HAS_ANY:-0}" -gt 0 ]; then
             # Has findings → REQUEST_CHANGES (blocks merge until resolved)
             echo "Found findings → REQUEST_CHANGES"
             PAYLOAD=$(mktemp)
             trap 'rm -f "$PAYLOAD"' EXIT
-            printf '%s' "$BODY" | jq -Rs --arg sha "$HEAD_SHA" \
-              '{body: ., event: "REQUEST_CHANGES", commit_id: $sha}' > "$PAYLOAD"
+            printf '%s' "$BODY" | jq -Rs \
+              '{body: ., event: "REQUEST_CHANGES"}' > "$PAYLOAD"
             gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
               --method POST \
               --input "$PAYLOAD" \
               --jq '.id'
           else
-            # No findings → regular comment (APPROVE from bot doesn't count for self-approval)
-            echo "No findings → comment"
-            gh pr comment "$PR_NUMBER" --body "$BODY"
+            # No findings → COMMENT review (supersedes old REQUEST_CHANGES; APPROVE from bot doesn't count for self-approval)
+            echo "No findings → COMMENT review"
+            PAYLOAD=$(mktemp)
+            trap 'rm -f "$PAYLOAD"' EXIT
+            printf '%s' "$BODY" | jq -Rs \
+              '{body: ., event: "COMMENT"}' > "$PAYLOAD"
+            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+              --method POST \
+              --input "$PAYLOAD" \
+              --jq '.id'
           fi
 
   fix:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -95,15 +95,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
+          REPO: ${{ github.repository }}
         run: |
-          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.body | startswith("# AI Code Review"))] | last | .id' 2>/dev/null || true)
-          if [ -n "$COMMENT_ID" ] && [ "$COMMENT_ID" != "null" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" \
+          REVIEW_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | select(.body | startswith("# AI Code Review"))] | last | .id' 2>/dev/null || true)
+          if [ -n "$REVIEW_ID" ] && [ "$REVIEW_ID" != "null" ]; then
+            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" \
               --jq '.body' > /tmp/existing-review.md
-            echo "Found existing review comment $COMMENT_ID"
+            echo "Found existing review $REVIEW_ID"
           else
-            echo "No existing review comment"
+            echo "No existing review"
           fi
 
       - name: Run review with regression check
@@ -325,10 +326,50 @@ jobs:
 
       - name: Comment on PR
         if: always() && (github.event_name == 'pull_request' || inputs.pr_number)
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88  # v3.0.5
-        with:
-          path: /tmp/review.md
-          header: ai-review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          BODY=$(cat /tmp/review.md)
+
+          # Count findings to decide review event
+          HAS_MAJOR=$(echo "$BODY" | grep -ciE 'severity:\s*major' || true)
+          HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:' || true)
+
+          # Fetch the current SHA for the review
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+
+          # Determine review event
+          if [ "${HAS_MAJOR:-0}" -gt 0 ]; then
+            EVENT="REQUEST_CHANGES"
+            echo "Found $HAS_MAJOR Major findings → REQUEST_CHANGES"
+          elif [ "${HAS_ANY:-0}" -gt 0 ]; then
+            # Minor-only → still request changes so they get resolved
+            EVENT="REQUEST_CHANGES"
+            echo "Found Minor findings → REQUEST_CHANGES"
+          else
+            EVENT="APPROVE"
+            echo "No findings → APPROVE"
+          fi
+
+          # Create PR review via API (posts as a review comment that must be resolved)
+          PAYLOAD=$(mktemp)
+          python3 -c "
+          import json, sys
+          body = sys.stdin.read()
+          print(json.dumps({'body': body, 'event': '$EVENT', 'commit_id': '$HEAD_SHA'}))
+          " <<< "$BODY" > "$PAYLOAD"
+
+          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --method POST \
+            --input "$PAYLOAD" \
+            --jq '.id'
+
+          rm -f "$PAYLOAD"
+          echo "Review submitted with event=$EVENT"
 
   fix:
     runs-on: ubuntu-latest
@@ -432,16 +473,16 @@ jobs:
           try:
               pr = os.environ['NUM']
               state_path = '/tmp/review-state.env'
-              r = subprocess.run(['gh','pr','view',pr,'--repo',os.environ['REPO'],'--json','comments'], capture_output=True, text=True)
+              r = subprocess.run(['gh','api',f'repos/{os.environ["REPO"]}/pulls/{pr}/reviews'], capture_output=True, text=True)
               if r.returncode:
-                  print(f'Failed to fetch PR comments: {r.stderr}', file=sys.stderr)
+                  print(f'Failed to fetch PR reviews: {r.stderr}', file=sys.stderr)
                   open(state_path,'w').write('NO_REVIEW=true\n')
                   sys.exit(0)
-              cs = json.loads(r.stdout).get('comments',[])
-              ai = [c for c in cs if c.get('body','').startswith('# AI Code Review') and ('github-actions' in (c.get('author',{}).get('login','') or '') or 'ai-review' in (c.get('author',{}).get('login','') or ''))]
+              reviews = json.loads(r.stdout)
+              ai = [c for c in reviews if c.get('body','').startswith('# AI Code Review') and ('github-actions' in (c.get('user',{}).get('login','') or '') or 'ai-review' in (c.get('user',{}).get('login','') or ''))]
               if not ai:
                   open(state_path,'w').write('NO_REVIEW=true\n'); print('NO_REVIEW'); sys.exit(0)
-              ai.sort(key=lambda c: c.get('createdAt','')); latest = ai[-1]
+              ai.sort(key=lambda c: c.get('submitted_at','')); latest = ai[-1]
               body = latest.get('body','')
               if not body.strip():
                   print('Review body empty', file=sys.stderr)
@@ -739,10 +780,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number }}
+          REPO: ${{ github.repository }}
         run: |
           echo '{"body": ""}' > /tmp/review-context.json
-          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.body | startswith("# AI Code Review"))] | last | {body: .body}' \
+          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | select(.body | startswith("# AI Code Review"))] | last | {body: .body}' \
             > /tmp/review-context.json 2>/dev/null || true
 
       - name: Autofix loop
@@ -891,8 +933,8 @@ jobs:
           python3 << 'PYEOF'
           import json, subprocess, os
           try:
-              r = subprocess.run(['gh','api',f'repos/{os.environ["GITHUB_REPOSITORY"]}/issues/{os.environ["PR_NUMBER"]}/comments',
-                  '--jq','[.[] | select(.body | startswith("# AI Code Review"))] | last | .body'],
+              r = subprocess.run(['gh','api',f'repos/{os.environ["GITHUB_REPOSITORY"]}/pulls/{os.environ["PR_NUMBER"]}/reviews',
+                  '--jq','[.[] | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | select(.body | startswith("# AI Code Review"))] | last | .body'],
                   capture_output=True, text=True)
               with open('/tmp/review-context.json','w') as f:
                   json.dump({'body': r.stdout.strip() if r.returncode == 0 else ''}, f)

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -333,25 +333,28 @@ jobs:
         run: |
           set -euo pipefail
 
-          BODY=$(cat /tmp/review.md)
+          BODY=$(cat /tmp/review.md 2>/dev/null) || BODY=""
 
           # Count findings
           HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:' || true)
 
           # Fetch the current SHA for the review
-          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha') || {
+            echo "Failed to fetch PR head SHA" >&2
+            exit 1
+          }
 
           if [ "${HAS_ANY:-0}" -gt 0 ]; then
             # Has findings → REQUEST_CHANGES (blocks merge until resolved)
             echo "Found findings → REQUEST_CHANGES"
             PAYLOAD=$(mktemp)
+            trap 'rm -f "$PAYLOAD"' EXIT
             printf '%s' "$BODY" | jq -Rs --arg sha "$HEAD_SHA" \
               '{body: ., event: "REQUEST_CHANGES", commit_id: $sha}' > "$PAYLOAD"
             gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
               --method POST \
               --input "$PAYLOAD" \
               --jq '.id'
-            rm -f "$PAYLOAD"
           else
             # No findings → regular comment (APPROVE from bot doesn't count for self-approval)
             echo "No findings → comment"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -98,7 +98,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
-          REVIEW_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+          REVIEW_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
             --jq '[.[] | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | select(.body | startswith("# AI Code Review"))] | last | .id' 2>/dev/null || true)
           if [ -n "$REVIEW_ID" ] && [ "$REVIEW_ID" != "null" ]; then
             gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" \
@@ -360,33 +360,53 @@ jobs:
           trap 'rm -f "$PAYLOAD"' EXIT
 
           if [ -n "$EXISTING_REVIEW_ID" ] && [ "$EXISTING_REVIEW_ID" != "null" ]; then
-            # Existing review found — update its body
-            echo "Updating existing review $EXISTING_REVIEW_ID"
+            # Existing review found — check its state
+            CURRENT_STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID" \
+              --jq '.state' 2>/dev/null || echo "")
 
             if [ "${HAS_ANY:-0}" -gt 0 ]; then
-              # Findings → update body, keep REQUEST_CHANGES state
-              printf '%s' "$BODY" | jq -Rs '{body: .}' > "$PAYLOAD"
-              gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID" \
-                --method PUT \
-                --input "$PAYLOAD" \
-                --jq '.id'
-            else
-              # No findings → check current state
-              CURRENT_STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID" \
-                --jq '.state' 2>/dev/null || echo "")
+              # Findings exist — need REQUEST_CHANGES
               if [ "$CURRENT_STATE" = "CHANGES_REQUESTED" ]; then
-                # State needs to change RC → COMMENT — dismiss old, post new
-                echo "Dismissing RC review $EXISTING_REVIEW_ID"
-                gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID/dismissals" \
+                # Already RC — just update body
+                echo "Updating existing RC review $EXISTING_REVIEW_ID"
+                printf '%s' "$BODY" | jq -Rs '{body: .}' > "$PAYLOAD"
+                gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID" \
                   --method PUT \
-                  -f message="Re-review found no actionable issues." 2>/dev/null || true
+                  --input "$PAYLOAD" \
+                  --jq '.id'
+              else
+                # Not RC — need to dismiss old and create new RC
+                echo "Dismissing $CURRENT_STATE review $EXISTING_REVIEW_ID"
+                if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID/dismissals" \
+                  --method PUT \
+                  -f message="Superseded by review with findings." 2>/dev/null; then
+                  echo "::warning::Failed to dismiss old review — may still block PR"
+                fi
+                echo "Creating REQUEST_CHANGES review"
+                printf '%s' "$BODY" | jq -Rs '{body: ., event: "REQUEST_CHANGES"}' > "$PAYLOAD"
+                gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+                  --method POST \
+                  --input "$PAYLOAD" \
+                  --jq '.id'
+              fi
+            else
+              # No findings — need to clear any blocking state
+              if [ "$CURRENT_STATE" = "CHANGES_REQUESTED" ]; then
+                echo "Dismissing RC review $EXISTING_REVIEW_ID"
+                if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID/dismissals" \
+                  --method PUT \
+                  -f message="Re-review found no actionable issues." 2>/dev/null; then
+                  echo "::warning::Failed to dismiss RC — PR may still be blocked"
+                fi
+                # Post clean review after successful dismissal
                 printf '%s' "$BODY" | jq -Rs '{body: ., event: "COMMENT"}' > "$PAYLOAD"
                 gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
                   --method POST \
                   --input "$PAYLOAD" \
                   --jq '.id'
               else
-                # Already COMMENT — just update body
+                # Already clean — just update body
+                echo "Updating existing review $EXISTING_REVIEW_ID"
                 printf '%s' "$BODY" | jq -Rs '{body: .}' > "$PAYLOAD"
                 gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID" \
                   --method PUT \
@@ -426,13 +446,7 @@ jobs:
           fi
 
           # Build the review comment body (all findings, with resolve button)
-          COMMENT_BODY="## AI Review Findings
-
-All findings below must be resolved before merging. Click **Resolve conversation** on each thread once reviewed.
-
----
-
-$BODY"
+          COMMENT_BODY="## AI Review Findings"$'\n\n'"All findings below must be resolved before merging. Click **Resolve conversation** on each thread once reviewed."$'\n\n'"-----"$'\n\n'"${BODY}"
 
           # Delete old review comment if it exists
           if [ -n "$EXISTING_COMMENT_ID" ] && [ "$EXISTING_COMMENT_ID" != "null" ]; then

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1084,3 +1084,4 @@ jobs:
           gh workflow run pr-review.yml -f pr_number="$NUM" 2>/dev/null || true
 
 # ponytail: fixer edits repo files directly via agent tools; commit step stages the real diff.
+

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -109,6 +109,16 @@ jobs:
           fi
           echo "review_id=${REVIEW_ID:-}" >> "$GITHUB_OUTPUT"
 
+          # Get PR head SHA for review comments
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+          # Find existing review comment from this bot
+          COMMENT_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+            --paginate \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | select(.body | startswith("## AI Review Findings")) | .id] | last // empty' 2>/dev/null || true)
+          echo "comment_id=${COMMENT_ID:-}" >> "$GITHUB_OUTPUT"
+
       - name: Run review with regression check
         run: |
           set -euo pipefail
@@ -398,6 +408,49 @@ jobs:
               --input "$PAYLOAD" \
               --jq '.id'
           fi
+
+      - name: Post review comment
+        if: always() && (github.event_name == 'pull_request' || inputs.pr_number)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.fetch.outputs.head_sha }}
+          EXISTING_COMMENT_ID: ${{ steps.fetch.outputs.comment_id }}
+        run: |
+          set -euo pipefail
+
+          BODY=$(cat /tmp/review.md 2>/dev/null) || BODY=""
+          if [ -z "$BODY" ]; then
+            exit 0
+          fi
+
+          # Build the review comment body (all findings, with resolve button)
+          COMMENT_BODY="## AI Review Findings
+
+All findings below must be resolved before merging. Click **Resolve conversation** on each thread once reviewed.
+
+---
+
+$BODY"
+
+          # Delete old review comment if it exists
+          if [ -n "$EXISTING_COMMENT_ID" ] && [ "$EXISTING_COMMENT_ID" != "null" ]; then
+            echo "Deleting old review comment $EXISTING_COMMENT_ID"
+            gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$EXISTING_COMMENT_ID" \
+              --method DELETE 2>/dev/null || true
+          fi
+
+          # Post new review comment (requires file + line)
+          PAYLOAD=$(mktemp)
+          trap 'rm -f "$PAYLOAD"' EXIT
+          printf '%s' "$COMMENT_BODY" | jq -Rs \
+            --arg sha "$HEAD_SHA" \
+            '{body: ., commit_id: $sha, path: ".github/workflows/pr-review.yml", line: 1, side: "RIGHT"}' > "$PAYLOAD"
+          gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+            --method POST \
+            --input "$PAYLOAD" \
+            --jq '.id'
 
   fix:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -335,11 +335,22 @@ jobs:
 
           BODY=$(cat /tmp/review.md 2>/dev/null) || BODY=""
 
-          # Count findings
-          HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:' || true)
+          # Count actionable findings (Major or Critical only)
+          HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:\s*(major|critical)' || true)
+
+          # Dismiss any prior REQUEST_CHANGES from this bot
+          OLD_RC=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.state == "CHANGES_REQUESTED") | select(.user.login | test("github-actions|ai-review")) | .id] | last // empty' 2>/dev/null || true)
+          if [ -n "$OLD_RC" ]; then
+            echo "Dismissing old REQUEST_CHANGES review $OLD_RC"
+            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$OLD_RC" \
+              --method PUT \
+              -f event="COMMENT" \
+              -f body="Dismissed: re-review found no actionable issues." 2>/dev/null || true
+          fi
 
           if [ "${HAS_ANY:-0}" -gt 0 ]; then
-            # Has findings → REQUEST_CHANGES (blocks merge until resolved)
+            # Has actionable findings → REQUEST_CHANGES (blocks merge until resolved)
             echo "Found findings → REQUEST_CHANGES"
             PAYLOAD=$(mktemp)
             trap 'rm -f "$PAYLOAD"' EXIT
@@ -350,7 +361,7 @@ jobs:
               --input "$PAYLOAD" \
               --jq '.id'
           else
-            # No findings → COMMENT review (supersedes old REQUEST_CHANGES; APPROVE from bot doesn't count for self-approval)
+            # No actionable findings → COMMENT review
             echo "No findings → COMMENT review"
             PAYLOAD=$(mktemp)
             trap 'rm -f "$PAYLOAD"' EXIT

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -335,41 +335,31 @@ jobs:
 
           BODY=$(cat /tmp/review.md)
 
-          # Count findings to decide review event
-          HAS_MAJOR=$(echo "$BODY" | grep -ciE 'severity:\s*major' || true)
+          # Count findings
           HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:' || true)
 
           # Fetch the current SHA for the review
           HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
 
-          # Determine review event
-          if [ "${HAS_MAJOR:-0}" -gt 0 ]; then
-            EVENT="REQUEST_CHANGES"
-            echo "Found $HAS_MAJOR Major findings → REQUEST_CHANGES"
-          elif [ "${HAS_ANY:-0}" -gt 0 ]; then
-            # Minor-only → still request changes so they get resolved
-            EVENT="REQUEST_CHANGES"
-            echo "Found Minor findings → REQUEST_CHANGES"
+          if [ "${HAS_ANY:-0}" -gt 0 ]; then
+            # Has findings → REQUEST_CHANGES (blocks merge until resolved)
+            echo "Found findings → REQUEST_CHANGES"
+            PAYLOAD=$(mktemp)
+            python3 -c "
+            import json, sys
+            body = sys.stdin.read()
+            print(json.dumps({'body': body, 'event': 'REQUEST_CHANGES', 'commit_id': '$HEAD_SHA'}))
+            " <<< "$BODY" > "$PAYLOAD"
+            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+              --method POST \
+              --input "$PAYLOAD" \
+              --jq '.id'
+            rm -f "$PAYLOAD"
           else
-            EVENT="APPROVE"
-            echo "No findings → APPROVE"
+            # No findings → regular comment (APPROVE from bot doesn't count for self-approval)
+            echo "No findings → comment"
+            gh pr comment "$PR_NUMBER" --body "$BODY"
           fi
-
-          # Create PR review via API (posts as a review comment that must be resolved)
-          PAYLOAD=$(mktemp)
-          python3 -c "
-          import json, sys
-          body = sys.stdin.read()
-          print(json.dumps({'body': body, 'event': '$EVENT', 'commit_id': '$HEAD_SHA'}))
-          " <<< "$BODY" > "$PAYLOAD"
-
-          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --method POST \
-            --input "$PAYLOAD" \
-            --jq '.id'
-
-          rm -f "$PAYLOAD"
-          echo "Review submitted with event=$EVENT"
 
   fix:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -338,19 +338,8 @@ jobs:
           # Count actionable findings (Major or Critical only)
           HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:\s*(major|critical)' || true)
 
-          # Dismiss any prior REQUEST_CHANGES from this bot
-          OLD_RC=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.state == "CHANGES_REQUESTED") | select(.user.login | test("github-actions|ai-review")) | .id] | last // empty' 2>/dev/null || true)
-          if [ -n "$OLD_RC" ]; then
-            echo "Dismissing old REQUEST_CHANGES review $OLD_RC"
-            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$OLD_RC" \
-              --method PUT \
-              -f event="COMMENT" \
-              -f body="Dismissed: re-review found no actionable issues." 2>/dev/null || true
-          fi
-
           if [ "${HAS_ANY:-0}" -gt 0 ]; then
-            # Has actionable findings → REQUEST_CHANGES (blocks merge until resolved)
+            # Has actionable findings → REQUEST_CHANGES (supersedes old RC automatically)
             echo "Found findings → REQUEST_CHANGES"
             PAYLOAD=$(mktemp)
             trap 'rm -f "$PAYLOAD"' EXIT
@@ -361,7 +350,16 @@ jobs:
               --input "$PAYLOAD" \
               --jq '.id'
           else
-            # No actionable findings → COMMENT review
+            # No actionable findings → dismiss old RC, then COMMENT review
+            # (COMMENT alone doesn't dismiss RC — need explicit dismissals endpoint)
+            OLD_RC=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+              --jq '[.[] | select(.state == "CHANGES_REQUESTED") | select(.user.login | test("github-actions|ai-review")) | .id] | last // empty' 2>/dev/null || true)
+            if [ -n "$OLD_RC" ]; then
+              echo "Dismissing old REQUEST_CHANGES review $OLD_RC"
+              gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$OLD_RC/dismissals" \
+                --method PUT \
+                -f message="Re-review found no actionable issues." 2>/dev/null || true
+            fi
             echo "No findings → COMMENT review"
             PAYLOAD=$(mktemp)
             trap 'rm -f "$PAYLOAD"' EXIT

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -91,6 +91,7 @@ jobs:
           echo "Lines: $(wc -l < /tmp/review.diff)"
 
       - name: Fetch existing review
+        id: fetch
         if: github.event_name == 'pull_request' || inputs.pr_number
         env:
           GH_TOKEN: ${{ github.token }}
@@ -106,6 +107,7 @@ jobs:
           else
             echo "No existing review"
           fi
+          echo "review_id=${REVIEW_ID:-}" >> "$GITHUB_OUTPUT"
 
       - name: Run review with regression check
         run: |
@@ -330,6 +332,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
           REPO: ${{ github.repository }}
+          EXISTING_REVIEW_ID: ${{ steps.fetch.outputs.review_id }}
         run: |
           set -euo pipefail
 
@@ -340,35 +343,56 @@ jobs:
           fi
 
           # Count actionable findings (Major or Critical only)
-          HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:\s*\*{0,2}\s*(major|critical)' || true)
+          # Strip nested <details> blocks (old review context) before counting
+          HAS_ANY=$(echo "$BODY" | sed '/<details>/,/<\/details>/d' | grep -ciE 'severity:\s*\*{0,2}\s*(major|critical)' || true)
 
-          if [ "${HAS_ANY:-0}" -gt 0 ]; then
-            # Has actionable findings → REQUEST_CHANGES (supersedes old RC automatically)
-            echo "Found findings → REQUEST_CHANGES"
-            PAYLOAD=$(mktemp)
-            trap 'rm -f "$PAYLOAD"' EXIT
-            printf '%s' "$BODY" | jq -Rs \
-              '{body: ., event: "REQUEST_CHANGES"}' > "$PAYLOAD"
-            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --method POST \
-              --input "$PAYLOAD" \
-              --jq '.id'
-          else
-            # No actionable findings → dismiss old RC, then COMMENT review
-            # (COMMENT alone doesn't dismiss RC — need explicit dismissals endpoint)
-            OLD_RC=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.state == "CHANGES_REQUESTED") | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | .id] | last // empty' 2>/dev/null || true)
-            if [ -n "$OLD_RC" ]; then
-              echo "Dismissing old REQUEST_CHANGES review $OLD_RC"
-              gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$OLD_RC/dismissals" \
+          PAYLOAD=$(mktemp)
+          trap 'rm -f "$PAYLOAD"' EXIT
+
+          if [ -n "$EXISTING_REVIEW_ID" ] && [ "$EXISTING_REVIEW_ID" != "null" ]; then
+            # Existing review found — update its body
+            echo "Updating existing review $EXISTING_REVIEW_ID"
+
+            if [ "${HAS_ANY:-0}" -gt 0 ]; then
+              # Findings → update body, keep REQUEST_CHANGES state
+              printf '%s' "$BODY" | jq -Rs '{body: .}' > "$PAYLOAD"
+              gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID" \
                 --method PUT \
-                -f message="Re-review found no actionable issues." 2>/dev/null || true
+                --input "$PAYLOAD" \
+                --jq '.id'
+            else
+              # No findings → check current state
+              CURRENT_STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID" \
+                --jq '.state' 2>/dev/null || echo "")
+              if [ "$CURRENT_STATE" = "CHANGES_REQUESTED" ]; then
+                # State needs to change RC → COMMENT — dismiss old, post new
+                echo "Dismissing RC review $EXISTING_REVIEW_ID"
+                gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID/dismissals" \
+                  --method PUT \
+                  -f message="Re-review found no actionable issues." 2>/dev/null || true
+                printf '%s' "$BODY" | jq -Rs '{body: ., event: "COMMENT"}' > "$PAYLOAD"
+                gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+                  --method POST \
+                  --input "$PAYLOAD" \
+                  --jq '.id'
+              else
+                # Already COMMENT — just update body
+                printf '%s' "$BODY" | jq -Rs '{body: .}' > "$PAYLOAD"
+                gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$EXISTING_REVIEW_ID" \
+                  --method PUT \
+                  --input "$PAYLOAD" \
+                  --jq '.id'
+              fi
             fi
-            echo "No findings → COMMENT review"
-            PAYLOAD=$(mktemp)
-            trap 'rm -f "$PAYLOAD"' EXIT
-            printf '%s' "$BODY" | jq -Rs \
-              '{body: ., event: "COMMENT"}' > "$PAYLOAD"
+          else
+            # No existing review — create new
+            if [ "${HAS_ANY:-0}" -gt 0 ]; then
+              echo "Creating REQUEST_CHANGES review"
+              printf '%s' "$BODY" | jq -Rs '{body: ., event: "REQUEST_CHANGES"}' > "$PAYLOAD"
+            else
+              echo "Creating COMMENT review"
+              printf '%s' "$BODY" | jq -Rs '{body: ., event: "COMMENT"}' > "$PAYLOAD"
+            fi
             gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
               --method POST \
               --input "$PAYLOAD" \

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -113,8 +113,8 @@ jobs:
           HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
-          # Find existing review comment from this bot
-          COMMENT_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+          # Find existing comment from this bot on the PR issue
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
             --paginate \
             --jq '[.[] | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | select(.body | startswith("## AI Review Findings")) | .id] | last // empty' 2>/dev/null || true)
           echo "comment_id=${COMMENT_ID:-}" >> "$GITHUB_OUTPUT"
@@ -435,7 +435,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ steps.fetch.outputs.head_sha }}
           EXISTING_COMMENT_ID: ${{ steps.fetch.outputs.comment_id }}
         run: |
           set -euo pipefail
@@ -445,23 +444,20 @@ jobs:
             exit 0
           fi
 
-          # Build the review comment body (all findings, with resolve button)
-          COMMENT_BODY="## AI Review Findings"$'\n\n'"All findings below must be resolved before merging. Click **Resolve conversation** on each thread once reviewed."$'\n\n'"-----"$'\n\n'"${BODY}"
+          # Post as standard PR comment (no "Resolve conversation" but simpler and always works)
+          COMMENT_BODY="## AI Review Findings"$'\n\n'"All findings below must be resolved before merging."$'\n\n'"-----"$'\n\n'"${BODY}"
 
-          # Delete old review comment if it exists
+          # Delete old comment if it exists
           if [ -n "$EXISTING_COMMENT_ID" ] && [ "$EXISTING_COMMENT_ID" != "null" ]; then
-            echo "Deleting old review comment $EXISTING_COMMENT_ID"
-            gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$EXISTING_COMMENT_ID" \
+            echo "Deleting old comment $EXISTING_COMMENT_ID"
+            gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT_ID" \
               --method DELETE 2>/dev/null || true
           fi
 
-          # Post new review comment (requires file + line)
           PAYLOAD=$(mktemp)
           trap 'rm -f "$PAYLOAD"' EXIT
-          printf '%s' "$COMMENT_BODY" | jq -Rs \
-            --arg sha "$HEAD_SHA" \
-            '{body: ., commit_id: $sha, path: ".github/workflows/pr-review.yml", line: 1, side: "RIGHT"}' > "$PAYLOAD"
-          gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+          printf '%s' "$COMMENT_BODY" | jq -Rs '{body: .}' > "$PAYLOAD"
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
             --method POST \
             --input "$PAYLOAD" \
             --jq '.id'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -484,7 +484,7 @@ jobs:
                   print(f'Invalid JSON from gh api: {r.stdout[:200]}', file=sys.stderr)
                   open(state_path,'w').write('NO_REVIEW=true\n')
                   sys.exit(0)
-              ai = [c for c in reviews if c.get('body','').startswith('# AI Code Review') and ('github-actions' in (c.get('user',{}).get('login','') or '') or 'ai-review' in (c.get('user',{}).get('login','') or ''))]
+              ai = [c for c in reviews if c.get('body','').startswith('# AI Code Review') and (c.get('user',{}).get('login','') in ('github-actions[bot]', 'ai-review[bot]'))]
               if not ai:
                   open(state_path,'w').write('NO_REVIEW=true\n'); print('NO_REVIEW'); sys.exit(0)
               ai.sort(key=lambda c: c.get('submitted_at','')); latest = ai[-1]

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -353,7 +353,7 @@ jobs:
             # No actionable findings → dismiss old RC, then COMMENT review
             # (COMMENT alone doesn't dismiss RC — need explicit dismissals endpoint)
             OLD_RC=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.state == "CHANGES_REQUESTED") | select(.user.login | test("github-actions|ai-review")) | .id] | last // empty' 2>/dev/null || true)
+              --jq '[.[] | select(.state == "CHANGES_REQUESTED") | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | .id] | last // empty' 2>/dev/null || true)
             if [ -n "$OLD_RC" ]; then
               echo "Dismissing old REQUEST_CHANGES review $OLD_RC"
               gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$OLD_RC/dismissals" \

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -334,6 +334,10 @@ jobs:
           set -euo pipefail
 
           BODY=$(cat /tmp/review.md 2>/dev/null) || BODY=""
+          if [ -z "$BODY" ]; then
+            echo "No review body to post"
+            exit 0
+          fi
 
           # Count actionable findings (Major or Critical only)
           HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:\s*\*{0,2}\s*(major|critical)' || true)

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -478,7 +478,12 @@ jobs:
                   print(f'Failed to fetch PR reviews: {r.stderr}', file=sys.stderr)
                   open(state_path,'w').write('NO_REVIEW=true\n')
                   sys.exit(0)
-              reviews = json.loads(r.stdout)
+              try:
+                  reviews = json.loads(r.stdout)
+              except json.JSONDecodeError:
+                  print(f'Invalid JSON from gh api: {r.stdout[:200]}', file=sys.stderr)
+                  open(state_path,'w').write('NO_REVIEW=true\n')
+                  sys.exit(0)
               ai = [c for c in reviews if c.get('body','').startswith('# AI Code Review') and ('github-actions' in (c.get('user',{}).get('login','') or '') or 'ai-review' in (c.get('user',{}).get('login','') or ''))]
               if not ai:
                   open(state_path,'w').write('NO_REVIEW=true\n'); print('NO_REVIEW'); sys.exit(0)

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -345,11 +345,8 @@ jobs:
             # Has findings → REQUEST_CHANGES (blocks merge until resolved)
             echo "Found findings → REQUEST_CHANGES"
             PAYLOAD=$(mktemp)
-            python3 -c "
-            import json, sys
-            body = sys.stdin.read()
-            print(json.dumps({'body': body, 'event': 'REQUEST_CHANGES', 'commit_id': '$HEAD_SHA'}))
-            " <<< "$BODY" > "$PAYLOAD"
+            printf '%s' "$BODY" | jq -Rs --arg sha "$HEAD_SHA" \
+              '{body: ., event: "REQUEST_CHANGES", commit_id: $sha}' > "$PAYLOAD"
             gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
               --method POST \
               --input "$PAYLOAD" \

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -336,7 +336,7 @@ jobs:
           BODY=$(cat /tmp/review.md 2>/dev/null) || BODY=""
 
           # Count actionable findings (Major or Critical only)
-          HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:\s*(major|critical)' || true)
+          HAS_ANY=$(echo "$BODY" | grep -ciE 'severity:\s*\*{0,2}\s*(major|critical)' || true)
 
           if [ "${HAS_ANY:-0}" -gt 0 ]; then
             # Has actionable findings → REQUEST_CHANGES (supersedes old RC automatically)
@@ -785,7 +785,7 @@ jobs:
           echo '{"body": ""}' > /tmp/review-context.json
           gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
             --jq '[.[] | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | select(.body | startswith("# AI Code Review"))] | last | {body: .body}' \
-            > /tmp/review-context.json 2>/dev/null || true
+            > /tmp/review-context-tmp.json 2>/dev/null && mv /tmp/review-context-tmp.json /tmp/review-context.json || rm -f /tmp/review-context-tmp.json
 
       - name: Autofix loop
         id: loop

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -101,8 +101,6 @@ jobs:
           REVIEW_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
             --jq '[.[] | select(.user.login == "github-actions[bot]" or .user.login == "ai-review[bot]") | select(.body | startswith("# AI Code Review"))] | last | .id' 2>/dev/null || true)
           if [ -n "$REVIEW_ID" ] && [ "$REVIEW_ID" != "null" ]; then
-            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" \
-              --jq '.body' > /tmp/existing-review.md
             echo "Found existing review $REVIEW_ID"
           else
             echo "No existing review"
@@ -299,27 +297,8 @@ jobs:
 
           REVIEW_TMP=$(mktemp)
 
-          # Fetch existing review to fold it
-          EXISTING=""
-          if [ -f /tmp/existing-review.md ]; then
-            EXISTING=$(cat /tmp/existing-review.md)
-          fi
-
           echo "# AI Code Review" > "$REVIEW_TMP"
           echo "" >> "$REVIEW_TMP"
-
-          # Fold previous review if it exists
-          if [ -n "$EXISTING" ]; then
-            echo "<details>" >> "$REVIEW_TMP"
-            echo "<summary>Previous review (before this commit)</summary>" >> "$REVIEW_TMP"
-            echo "" >> "$REVIEW_TMP"
-            cat /tmp/existing-review.md >> "$REVIEW_TMP"
-            echo "" >> "$REVIEW_TMP"
-            echo "</details>" >> "$REVIEW_TMP"
-            echo "" >> "$REVIEW_TMP"
-            echo "---" >> "$REVIEW_TMP"
-            echo "" >> "$REVIEW_TMP"
-          fi
 
           if [ -n "$CONVERGENCE_REASON" ]; then
             echo "*Review completed: $CONVERGENCE_REASON*" >> "$REVIEW_TMP"


### PR DESCRIPTION
## What
AI review was posting sticky comments that don't block merge. Now uses GitHub PR Reviews API.

## Changes
-  when findings exist (blocks merge until resolved)
-  when no findings
- Fetch existing reviews from PR reviews API (not issue comments)
- All 3 jobs (review, fix, autofix) updated

## Behavior
- Like CodeRabbit: review comments must be resolved before merge
- Major findings → REQUEST_CHANGES
- Minor findings → REQUEST_CHANGES
- No findings → APPROVE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - AI-generated pull-request reviews are now managed directly through pull-request review activity.
  - Existing reviews are updated when appropriate, while new reviews accurately reflect whether actionable findings require changes or general comments.
  - Fix and autofix workflows now use the latest AI review context and provide clearer handling when review information cannot be retrieved or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->